### PR TITLE
Adds modulo operation to post processing.

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -178,6 +178,11 @@ bool decodeBLEJson(JsonObject& jsondata) {
                     case '+':
                       temp_val += post_proc[i + 1].as<double>();
                       break;
+                    case '%': {
+                      long val = (long)temp_val;
+                      temp_val = val % post_proc[i + 1].as<long>();
+                      break;
+                    }
                     case '<': {
                       long val = (long)temp_val;
                       temp_val = val << post_proc[i + 1].as<unsigned int>();


### PR DESCRIPTION
To use when data is encoded with 2 values combined. E.g 040d23 = 265507, 26.5 temp and 50.7 humidity.

To decode this with the JSON correctly I used this:
```
      "tempc":{
         "decoder":["value_from_hex_data", "manufacturerdata", 28, 6, false],
         "post_proc":["/", 1000, ">", 0, "/", 10]
      },
      "hum":{
         "decoder":["value_from_hex_data", "manufacturerdata", 28, 6, false],
         "post_proc":["%", 1000, "/", 10]
      }
```

Note that the shift was needed to keep the humidity value out of the temp.