### PR TITLE
Fix crash when the model_id is not found

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -330,14 +330,16 @@ int TheengsDecoder::getTheengModel(JsonDocument& doc, const char* model_id) {
       break;
     }
 
-    if (strlen(doc["model_id"].as<const char*>()) != mid_len) {
-      continue;
-    }
-
-    if (!strncmp(model_id, doc["model_id"], mid_len)) {
-      return i;
+    if (doc.containsKey("model_id")) {
+      if (strlen(doc["model_id"].as<const char*>()) != mid_len) {
+        continue;
+      }
+      if (!strncmp(model_id, doc["model_id"], mid_len)) {
+        return i;
+      }
     }
   }
+
   return -1;
 }
 


### PR DESCRIPTION
## Description:
Fix crash when the model_id can not be found in the list of decoder models

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
