### PR TITLE
Add minimum data length check for service/manufacturer data.

### DIFF
--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -48,11 +48,15 @@ Each device must provide a `brand`, `model`, `model_id`, `condition`, and `prope
 - "name"
 - "uuid"
 
-The second parameter is how the data should be tested. Valid inputs are:
+The second parameter is variable. If required, further qualification can be made by setting a minimum data length in the case of "servicedata" or "manufacturerdata" as the first condition. This is a numeric value that specifies the minimum length of the data to accept as a valid input. If no minimum data length is defined the second paramater must indicate how the data should be tested. Valid inputs are:
 - "contain" tests if the specified value (see below) exists the data source 
 - "index" tests if the specified value exists at the index location (see below) in the data source
 
-The third parameter can be either the index value or the data value to find. If the second parameter is `contain`, the third parameter should be the value to look for in the data source. If the second parameter is `index`, the third parameter should be the location in the data source to look for the value provided as the fourth parameter.
+Examples:
+`"condition":["servicedata", "index", 0, "0804"` -- no data length check
+`"condition":["servicedata", 40, "index", 0, "0804"` -- data length must be equal to or greater than 40 bytes
+
+The third parameter (fourth if minimum data length is specified) can be either the index value or the data value to find. If the second parameter is `contain`, the third parameter should be the value to look for in the data source. If the second parameter is `index`, the third parameter should be the location in the data source to look for the value provided as the fourth parameter.
 
 `condition` can have multiple conditions chanined together using '|' and '&' between them.  
 For example: `"condition":["servicedata", "index", 0, "0804", '|', "servicedata", "index", 0, "8804"]`  

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -116,14 +116,32 @@ bool TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
 
     JsonArray condition = doc["condition"];
     bool match = false;
+    size_t min_len = m_minMfgDataLen;
+
     for (unsigned int i = 0; i < condition.size();) {
       const char* data_str;
-      if (strstr(condition[i].as<const char*>(), "servicedata") != nullptr &&
-          svc_data != nullptr && strlen(svc_data) >= m_minSvcDataLen) {
-        data_str = svc_data;
-      } else if (strstr(condition[i].as<const char*>(), "manufacturerdata") != nullptr &&
-                 mfg_data != nullptr && strlen(mfg_data) >= m_minMfgDataLen) {
-        data_str = mfg_data;
+      if (strstr(condition[i].as<const char*>(), "servicedata") != nullptr) {
+        if (condition[i + 1].is<size_t>()) {
+          min_len = condition[i + 1].as<size_t>();
+          i++;
+        }
+
+        if (svc_data != nullptr && strlen(svc_data) >= min_len) {
+          data_str = svc_data;
+        } else {
+          break;
+        }
+      } else if (strstr(condition[i].as<const char*>(), "manufacturerdata") != nullptr) {
+        if (condition[i + 1].is<size_t>()) {
+          min_len = condition[i + 1].as<size_t>();
+          i++;
+        }
+
+        if (mfg_data != nullptr && strlen(mfg_data) >= min_len) {
+          data_str = mfg_data;
+        } else {
+          break;
+        }
       } else if (strstr(condition[i].as<const char*>(), "name") != nullptr && dev_name != nullptr) {
         data_str = dev_name;
       } else if (strstr(condition[i].as<const char*>(), "uuid") != nullptr && svc_uuid != nullptr) {

--- a/src/devices/LYWSD03MMC_PVVX_json.h
+++ b/src/devices/LYWSD03MMC_PVVX_json.h
@@ -1,12 +1,12 @@
 #include "common_props.h"
 
-const char* _LYWSD03MMC_PVVX_json = "{\"brand\":\"Xiaomi\",\"model\":\"LYWSD03MMC\",\"model_id\":\"LYWSD03MMC_PVVX\",\"condition\":[\"servicedata\",\"index\",6,\"38c1a4\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true],\"post_proc\":[\"/\",100]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",16,4,true],\"post_proc\":[\"/\",100]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",24,2,false]},\"volt\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",20,4,true],\"post_proc\":[\"/\",1000]}}}";
+const char* _LYWSD03MMC_PVVX_json = "{\"brand\":\"Xiaomi\",\"model\":\"LYWSD03MMC\",\"model_id\":\"LYWSD03MMC_PVVX\",\"condition\":[\"servicedata\",30,\"index\",6,\"38c1a4\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true],\"post_proc\":[\"/\",100]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",16,4,true],\"post_proc\":[\"/\",100]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",24,2,false]},\"volt\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",20,4,true],\"post_proc\":[\"/\",1000]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
    "model":"LYWSD03MMC",
    "model_id":"LYWSD03MMC_PVVX",
-   "condition":["servicedata", "index",6 , "38c1a4"],
+   "condition":["servicedata", 30, "index",6 , "38c1a4"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "servicedata", 12, 4, true],

--- a/src/devices/WS02_json.h
+++ b/src/devices/WS02_json.h
@@ -1,11 +1,11 @@
-const char* _WS02_json = "{\"brand\":\"ThermoBeacon\",\"model\":\"WS02\",\"model_id\":\"WS02\",\"condition\":[\"manufacturerdata\",\"contain\",\"100000001a11\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true],\"post_proc\":[\"/\",16]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true],\"post_proc\":[\"/\",16]},\"volt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true],\"post_proc\":[\"/\",1000]}}}";
+const char* _WS02_json = "{\"brand\":\"ThermoBeacon\",\"model\":\"WS02\",\"model_id\":\"WS02\",\"condition\":[\"manufacturerdata\",40,\"contain\",\"100000001a11\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true],\"post_proc\":[\"/\",16]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true],\"post_proc\":[\"/\",16]},\"volt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true],\"post_proc\":[\"/\",1000]}}}";
 
 /*R""""(
 {
    "brand":"ThermoBeacon",
    "model":"WS02",
    "model_id":"WS02",
-   "condition":["manufacturerdata", "contain", "100000001a11"],
+   "condition":["manufacturerdata", 40, "contain", "100000001a11"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true],

--- a/src/devices/iBeacon_json.h
+++ b/src/devices/iBeacon_json.h
@@ -1,11 +1,11 @@
-const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"IBEACON\",\"model_id\":\"IBEACON\",\"condition\":[\"manufacturerdata\",\"index\",0,\"4c00\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"power\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]}}}";
+const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"IBEACON\",\"model_id\":\"IBEACON\",\"condition\":[\"manufacturerdata\",50,\"index\",0,\"4c00\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"power\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]}}}";
 
 /*R""""(
 {
    "brand":"GENERIC",
    "model":"IBEACON",
    "model_id":"IBEACON",
-   "condition":["manufacturerdata", "index", 0, "4c00"],
+   "condition":["manufacturerdata", 50, "index", 0, "4c00"],
    "properties":{
       "mfid":{
          "decoder":["string_from_hex_data", "manufacturerdata", 0, 4]

--- a/src/devices/iNode_json.h
+++ b/src/devices/iNode_json.h
@@ -1,10 +1,10 @@
-const char* _iNode_json = "{\"brand\":\"iNode\",\"model\":\"Energy Meter\",\"model_id\":\"INEM\",\"condition\":[\"manufacturerdata\",\"index\",0,\"9082\"],\"properties\":{\".cal\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true],\"post_proc\":[\"&\",16383]},\"power\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",4,4,true],\"post_proc\":[\"/\",\".cal\",\"*\",60000]},\"energy\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",8,4,true],\"post_proc\":[\"/\",\".cal\"]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2,true,false],\"post_proc\":[\">\",4,\"-\",2,\"*\",10]}}}";
+const char* _iNode_json = "{\"brand\":\"iNode\",\"model\":\"Energy Meter\",\"model_id\":\"INEM\",\"condition\":[\"manufacturerdata\",26,\"index\",0,\"9082\"],\"properties\":{\".cal\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true],\"post_proc\":[\"&\",16383]},\"power\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",4,4,true],\"post_proc\":[\"/\",\".cal\",\"*\",60000]},\"energy\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",8,4,true],\"post_proc\":[\"/\",\".cal\"]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2,true,false],\"post_proc\":[\">\",4,\"-\",2,\"*\",10]}}}";
 /*R""""(
 {
    "brand":"iNode",
    "model":"Energy Meter",
    "model_id":"INEM",
-   "condition":["manufacturerdata", "index", 0, "9082"],
+   "condition":["manufacturerdata", 26, "index", 0, "9082"],
    "properties":{
       ".cal":{
          "decoder":["value_from_hex_data", "manufacturerdata", 16, 4, true],


### PR DESCRIPTION
## Description:
Add optional minimum data length parameter to device JSON.
    
When defining device detection conditions in some cases it may be required to check the length of
the service or manufacturer data on a per device basis.

This change allows for an optional value to be added to the "conditions" array for the minimum data length to be specified.

Before:
"condition":["manufacturerdata", "index", 0, "4c00"]

After:
"condition":["manufacturerdata", 50, "index", 0, "4c00"] // check that the manufacturer data is at least 50 bytes in length.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
