### PR TITLE
Extend condition checks for service/manufacturer data length.

### DIFF
--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -48,15 +48,15 @@ Each device must provide a `brand`, `model`, `model_id`, `condition`, and `prope
 - "name"
 - "uuid"
 
-The second parameter is variable. If required, further qualification can be made by setting a minimum data length in the case of "servicedata" or "manufacturerdata" as the first condition. This is a numeric value that specifies the minimum length of the data to accept as a valid input. If no minimum data length is defined the second paramater must indicate how the data should be tested. Valid inputs are:
+The second parameter is variable. If required, further qualification can be made by setting a conditional data length in the case of "servicedata" or "manufacturerdata" as the first condition. This is an operator in the form of `">" , ">=" , "=" , "<" , "<="` followed by the third parameter being a numeric value that specifies the length of the data to accept. If no data length is defined the second paramater must indicate how the data should be tested. Valid inputs are:
 - "contain" tests if the specified value (see below) exists the data source 
 - "index" tests if the specified value exists at the index location (see below) in the data source
 
 Examples:
 `"condition":["servicedata", "index", 0, "0804"` -- no data length check
-`"condition":["servicedata", 40, "index", 0, "0804"` -- data length must be equal to or greater than 40 bytes
+`"condition":["servicedata", ">=", 40, "index", 0, "0804"` -- data length must be equal to or greater than 40 bytes
 
-The third parameter (fourth if minimum data length is specified) can be either the index value or the data value to find. If the second parameter is `contain`, the third parameter should be the value to look for in the data source. If the second parameter is `index`, the third parameter should be the location in the data source to look for the value provided as the fourth parameter.
+The third parameter (fifth if data length is specified) can be either the index value or the data value to find. If the second (fourth if data length specified) parameter is `contain`, the next parameter should be the value to look for in the data source. If the second (fourth if data length specified) parameter is `index`, the next parameter should be the location in the data source to look for the value.
 
 `condition` can have multiple conditions chanined together using '|' and '&' between them.  
 For example: `"condition":["servicedata", "index", 0, "0804", '|', "servicedata", "index", 0, "8804"]`  

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -43,6 +43,7 @@ private:
   void reverse_hex_data(const char* in, char* out, int l);
   long value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true);
   bool data_index_is_valid(const char* str, size_t index, size_t len);
+  int data_length_is_valid(size_t data_len, size_t default_min, JsonArray& condition, int idx);
   std::string sanitizeJsonKey(const char* key_in);
 
   size_t m_docMax = 4096;

--- a/src/devices/IBT_2X_json.h
+++ b/src/devices/IBT_2X_json.h
@@ -1,11 +1,11 @@
-const char* _IBT_2X_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-2X\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\">=\",24,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_2X_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-2X\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",24,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
    "brand":"Inkbird",
    "model":"iBBQ",
    "model_id":"IBT-2X",
-   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", ">=", 24, "index", 0, "0000"],
+   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", "=", 24, "index", 0, "0000"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "manufacturerdata", 16, 4, true, false],

--- a/src/devices/IBT_2X_json.h
+++ b/src/devices/IBT_2X_json.h
@@ -1,11 +1,11 @@
-const char* _IBT_2X_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-2X\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",24,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_2X_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-2X\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\">=\",24,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
    "brand":"Inkbird",
    "model":"iBBQ",
    "model_id":"IBT-2X",
-   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", 24, "index", 0, "0000"],
+   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", ">=", 24, "index", 0, "0000"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "manufacturerdata", 16, 4, true, false],

--- a/src/devices/IBT_4XS_json.h
+++ b/src/devices/IBT_4XS_json.h
@@ -1,11 +1,11 @@
-const char* _IBT_4XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-4XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\">=\",36,\"index\",0,\"00000000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_4XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-4XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",36,\"index\",0,\"00000000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
    "brand":"Inkbird",
    "model":"iBBQ",
    "model_id":"IBT-4XS",
-   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", ">=" ,36 ,"index", 0, "00000000"],
+   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", "=" ,36 ,"index", 0, "00000000"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],

--- a/src/devices/IBT_4XS_json.h
+++ b/src/devices/IBT_4XS_json.h
@@ -1,11 +1,11 @@
-const char* _IBT_4XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-4XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",36,\"index\",0,\"00000000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_4XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-4XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\">=\",36,\"index\",0,\"00000000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
    "brand":"Inkbird",
    "model":"iBBQ",
    "model_id":"IBT-4XS",
-   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata",36 ,"index", 0, "00000000"],
+   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", ">=" ,36 ,"index", 0, "00000000"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],

--- a/src/devices/IBT_6XS_json.h
+++ b/src/devices/IBT_6XS_json.h
@@ -1,11 +1,11 @@
-const char* _IBT_6XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-6XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",40,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_6XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-6XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\">=\",40,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
    "brand":"Inkbird",
    "model":"iBBQ",
    "model_id":"IBT-6XS",
-   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", 40, "index", 0, "0000"],
+   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata",">=", 40, "index", 0, "0000"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "manufacturerdata", 16, 4, true, false],

--- a/src/devices/IBT_6XS_json.h
+++ b/src/devices/IBT_6XS_json.h
@@ -1,11 +1,11 @@
-const char* _IBT_6XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-6XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\">=\",40,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_6XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-6XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",40,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
    "brand":"Inkbird",
    "model":"iBBQ",
    "model_id":"IBT-6XS",
-   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata",">=", 40, "index", 0, "0000"],
+   "condition":["name", "index", 0, "iBBQ","&","manufacturerdata","=", 40, "index", 0, "0000"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "manufacturerdata", 16, 4, true, false],

--- a/src/devices/TPMS_json.h
+++ b/src/devices/TPMS_json.h
@@ -1,10 +1,10 @@
-const char* _TPMS_json = "{\"brand\":\"GENERIC\",\"model\":\"TPMS\",\"model_id\":\"TPMS1\",\"condition\":[\"name\",\"index\",0,\"TPMS1_10CA8F\"],\"properties\":{\"count\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",5,1,false],\"post_proc\":[\"+\",1]},\"pres\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,8,true],\"post_proc\":[\"/\",1000]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,8,true],\"post_proc\":[\"/\",100]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,2,true]},\"alarm\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",35,1,false],\"is_bool\":1}}}";
+const char* _TPMS_json = "{\"brand\":\"GENERIC\",\"model\":\"TPMS\",\"model_id\":\"TPMS1\",\"condition\":[\"manufacturerdata\",\"=\",36,\"&\",\"name\",\"index\",0,\"TPMS1_10CA8F\"],\"properties\":{\"count\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",5,1,false],\"post_proc\":[\"+\",1]},\"pres\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,8,true],\"post_proc\":[\"/\",1000]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,8,true],\"post_proc\":[\"/\",100]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,2,true]},\"alarm\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",35,1,false],\"is_bool\":1}}}";
 /*R""""(
 {
    "brand":"GENERIC",
    "model":"TPMS",
    "model_id":"TPMS1",
-   "condition":["name", "index", 0, "TPMS1_10CA8F"],
+   "condition":["manufacturerdata", "=", 36, "&", "name", "index", 0, "TPMS1_10CA8F"],
    "properties":{
       "count":{
          "decoder":["value_from_hex_data", "manufacturerdata", 5, 1, false],

--- a/src/devices/WS02_json.h
+++ b/src/devices/WS02_json.h
@@ -1,11 +1,11 @@
-const char* _WS02_json = "{\"brand\":\"ThermoBeacon\",\"model\":\"WS02\",\"model_id\":\"WS02\",\"condition\":[\"manufacturerdata\",40,\"contain\",\"100000001a11\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true],\"post_proc\":[\"/\",16]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true],\"post_proc\":[\"/\",16]},\"volt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true],\"post_proc\":[\"/\",1000]}}}";
+const char* _WS02_json = "{\"brand\":\"ThermoBeacon\",\"model\":\"WS02\",\"model_id\":\"WS02\",\"condition\":[\"manufacturerdata\",\">=\",40,\"contain\",\"100000001a11\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true],\"post_proc\":[\"/\",16]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true],\"post_proc\":[\"/\",16]},\"volt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true],\"post_proc\":[\"/\",1000]}}}";
 
 /*R""""(
 {
    "brand":"ThermoBeacon",
    "model":"WS02",
    "model_id":"WS02",
-   "condition":["manufacturerdata", 40, "contain", "100000001a11"],
+   "condition":["manufacturerdata", ">=", 40, "contain", "100000001a11"],
    "properties":{
       "tempc":{
          "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true],

--- a/src/devices/iBeacon_json.h
+++ b/src/devices/iBeacon_json.h
@@ -1,11 +1,11 @@
-const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"IBEACON\",\"model_id\":\"IBEACON\",\"condition\":[\"manufacturerdata\",50,\"index\",0,\"4c00\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"power\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]}}}";
+const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"IBEACON\",\"model_id\":\"IBEACON\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c00\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"power\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]}}}";
 
 /*R""""(
 {
    "brand":"GENERIC",
    "model":"IBEACON",
    "model_id":"IBEACON",
-   "condition":["manufacturerdata", 50, "index", 0, "4c00"],
+   "condition":["manufacturerdata", "=", 50, "index", 0, "4c00"],
    "properties":{
       "mfid":{
          "decoder":["string_from_hex_data", "manufacturerdata", 0, 4]

--- a/src/devices/iNode_json.h
+++ b/src/devices/iNode_json.h
@@ -1,10 +1,10 @@
-const char* _iNode_json = "{\"brand\":\"iNode\",\"model\":\"Energy Meter\",\"model_id\":\"INEM\",\"condition\":[\"manufacturerdata\",26,\"index\",0,\"9082\"],\"properties\":{\".cal\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true,false],\"post_proc\":[\"&\",16383]},\"power\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",4,4,true,false],\"post_proc\":[\"/\",\".cal\",\"*\",60000]},\"energy\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",8,4,true,false],\"post_proc\":[\"/\",\".cal\"]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2,true,false],\"post_proc\":[\">\",4,\"-\",2,\"*\",10]}}}";
+const char* _iNode_json = "{\"brand\":\"iNode\",\"model\":\"Energy Meter\",\"model_id\":\"INEM\",\"condition\":[\"manufacturerdata\",\"=\",26,\"index\",0,\"9082\"],\"properties\":{\".cal\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true,false],\"post_proc\":[\"&\",16383]},\"power\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",4,4,true,false],\"post_proc\":[\"/\",\".cal\",\"*\",60000]},\"energy\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",8,4,true,false],\"post_proc\":[\"/\",\".cal\"]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2,true,false],\"post_proc\":[\">\",4,\"-\",2,\"*\",10]}}}";
 /*R""""(
 {
    "brand":"iNode",
    "model":"Energy Meter",
    "model_id":"INEM",
-   "condition":["manufacturerdata", 26, "index", 0, "9082"],
+   "condition":["manufacturerdata", "=", 26, "index", 0, "9082"],
    "properties":{
       ".cal":{
          "decoder":["value_from_hex_data", "manufacturerdata", 16, 4, true, false],


### PR DESCRIPTION
## Description:
This adds an extra operator parameter when checking the length of the service/manufacturer data.

Valid inputs are ">" , ">=" , "=" , "<" , "<=".

Usage: `"condition":["manufacturerdata", "=", 50, "index", 0, "4c00"],`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
