### PR TITLE
Re-add impedance to Mi Scale 2 decoder

### DIFF
--- a/src/devices/XMTZC05HM_json.h
+++ b/src/devices/XMTZC05HM_json.h
@@ -1,6 +1,6 @@
 #include "common_props.h"
 
-const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100]}}}";
+const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100],\"impedance\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
@@ -25,6 +25,9 @@ const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"
          "condition":["servicedata", 1, "3"],
          "decoder":["value_from_hex_data", "servicedata", 22, 4, true, false],
          "post_proc":["/", 100]
+      },
+      "impedance":{
+         "decoder":["value_from_hex_data", "servicedata", 18, 4, true, false]
       }
    }
 })"""";*/

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -66,6 +66,10 @@ const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\"
       "weight":{
          "unit":"kg",
          "name":"weight"
+      },
+      "impedance":{
+         "unit":"Ω",
+         "name":"impedance"
       }
    }
 })"""";*/

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -59,7 +59,7 @@ const char* _common_BVTH_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"na
    }
 })"""";*/
 
-const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\":\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
+const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\",\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
 /*R""""(
 {
    "properties":{

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -68,7 +68,7 @@ const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\"
          "name":"weight"
       },
       "impedance":{
-         "unit":"Ω",
+         "unit":"Ohm",
          "name":"impedance"
       }
    }

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -59,7 +59,7 @@ const char* _common_BVTH_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"na
    }
 })"""";*/
 
-const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\"}}}";
+const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\":\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
 /*R""""(
 {
    "properties":{


### PR DESCRIPTION
## Description:
Re-adding the previously reported impedance of Mi Body Scale v2, to allow for further body composition calculations.

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
