### PR TITLE
Re-add impedance to Mi Scale 2 decoder

### DIFF
--- a/src/devices/XMTZC05HM_json.h
+++ b/src/devices/XMTZC05HM_json.h
@@ -1,12 +1,12 @@
 #include "common_props.h"
 
-const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100]},\"impedance\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false]}}}";
+const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"0x181b\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100]},\"impedance\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"Miscale_v2",
    "model_id":"XMTZC05HM",
-   "condition":["uuid", "contain", "181b"],
+   "condition":["uuid", "contain", "0x181b"],
    "properties":{
       "unit":{
          "condition":["servicedata", 1, "2"],

--- a/src/devices/XMTZC05HM_json.h
+++ b/src/devices/XMTZC05HM_json.h
@@ -1,6 +1,6 @@
 #include "common_props.h"
 
-const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100]}}}";
+const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100],\"impedance\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
@@ -25,6 +25,9 @@ const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"
          "condition":["servicedata", 1, "3"],
          "decoder":["value_from_hex_data", "servicedata", 22, 4, true, false],
          "post_proc":["/", 100]
+      },
+      "impedance":{
+         "decoder":["value_from_hex_data", "servicedata", 18, 4, true, false]
       }
    }
 })"""";*/

--- a/src/devices/XMTZC05HM_json.h
+++ b/src/devices/XMTZC05HM_json.h
@@ -1,12 +1,12 @@
 #include "common_props.h"
 
-const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"0x181b\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100]},\"impedance\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false]}}}";
+const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"181b\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100]},\"impedance\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"Miscale_v2",
    "model_id":"XMTZC05HM",
-   "condition":["uuid", "contain", "0x181b"],
+   "condition":["uuid", "contain", "181b"],
    "properties":{
       "unit":{
          "condition":["servicedata", 1, "2"],

--- a/src/devices/XMTZC05HM_json.h
+++ b/src/devices/XMTZC05HM_json.h
@@ -1,6 +1,6 @@
 #include "common_props.h"
 
-const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100],\"impedance\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false]}}}";
+const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",22,4,true,false],\"post_proc\":[\"/\",100]},\"impedance\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",

--- a/src/devices/XMTZC05HM_json.h
+++ b/src/devices/XMTZC05HM_json.h
@@ -32,4 +32,4 @@ const char* _XMTZC05HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"
    }
 })"""";*/
 
-const char* _XMTZC05HM_json_props = _common_weight_props;
+const char* _XMTZC05HM_json_props = _common_weight_impedance_props;

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -66,6 +66,10 @@ const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\"
       "weight":{
          "unit":"kg",
          "name":"weight"
+      },
+      "impedance":{
+         "unit":"Ω",
+         "name":"impedance"
       }
    }
 })"""";*/

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -59,7 +59,7 @@ const char* _common_BVTH_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"na
    }
 })"""";*/
 
-const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\",\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
+const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\"},\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
 /*R""""(
 {
    "properties":{

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -59,7 +59,7 @@ const char* _common_BVTH_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"na
    }
 })"""";*/
 
-const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\":\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
+const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\",\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
 /*R""""(
 {
    "properties":{

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -68,7 +68,7 @@ const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\"
          "name":"weight"
       },
       "impedance":{
-         "unit":"Ω",
+         "unit":"Ohm",
          "name":"impedance"
       }
    }

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -70,4 +70,19 @@ const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\"
    }
 })"""";*/
 
+const char* _common_weight_impedance_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\"},\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
+/*R""""(
+{
+   "properties":{
+      "weight":{
+         "unit":"kg",
+         "name":"weight"
+      }
+      "impedance":{
+         "unit":"Ohm",
+         "name":"impedance"
+      }
+   }
+})"""";*/
+
 #endif

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -59,17 +59,13 @@ const char* _common_BVTH_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"na
    }
 })"""";*/
 
-const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\"},\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
+const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\"}}}";
 /*R""""(
 {
    "properties":{
       "weight":{
          "unit":"kg",
          "name":"weight"
-      },
-      "impedance":{
-         "unit":"Ohm",
-         "name":"impedance"
       }
    }
 })"""";*/

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -59,7 +59,7 @@ const char* _common_BVTH_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"na
    }
 })"""";*/
 
-const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\"}}}";
+const char* _common_weight_props = "{\"properties\":{\"weight\":{\"unit\":\"kg\",\"name\":\"weight\":\"impedance\":{\"unit\":\"Ohm\",\"name\":\"impedance\"}}}";
 /*R""""(
 {
    "properties":{

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -58,6 +58,7 @@ const char* expected_mfg[] = {
 const char* expected_uuid[] = {
     "{\"brand\":\"Xiaomi\",\"model\":\"Miband\",\"model_id\":\"MiBand\",\"steps\":7842}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v1\",\"model_id\":\"XMTZC04HM\",\"unit\":\"kg\",\"weight\":61.75}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"unit\":\"kg\",\"weight\":72.45,\"impedance\":503}",
     "{\"brand\":\"Mokosmart\",\"model\":\"Beacon\",\"model_id\":\"Mokobeacon\",\"batt\":100,\"x_axis\":-24576,\"y_axis\":-3841,\"z_axis\":-8189}",
     "{\"brand\":\"Mokosmart\",\"model\":\"BeaconX Pro\",\"model_id\":\"MBXPRO\",\"tempc\":27.4,\"tempf\":81.32,\"hum\":49.4,\"volt\":3.247}",
 };
@@ -119,6 +120,7 @@ const char* test_mfgdata[][3] = {
 const char* test_uuid[][4] = {
     {"MiBand", "fee0", "servicedata", "a21e0000"},
     {"Miscale", "0x181d", "servicedata", "223e30b207010708031f"},
+    {"Miscale_v2", "0x181b", "servicedata", "0284e5070c170c301df7019a38"},
     {"Mokobeacon", "0xff01", "servicedata", "64000000005085a000f0ffe003"},
     {"MokoXPro", "0xfeab", "servicedata", "70000a011201ee0caf03def14635998a"},
 };


### PR DESCRIPTION
## Description:
Re-adding the previously reported impedance of Mi Body Scale v2, to allow for further body composition calculations.

And FINALLY got all the curly brackets right *blush* 

## Checklist:
Tested and working fine

… ,"brand":"Xiaomi","model":"Miscale_v2","model_id":"XMTZC05HM","unit":"kg","weight":xx.xx,"impedance":xxx}

along with Mi Scale v2 fix as discussed in

https://github.com/1technophile/OpenMQTTGateway/issues/1123
