### PR TITLE
Fix manufacturer data not checked for property condition.

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -230,7 +230,9 @@ bool TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
 
         if (prop_condition.isNull() || strstr((const char*)prop_condition[0], "servicedata") != nullptr ||
             strstr((const char*)prop_condition[0], "manufacturerdata") != nullptr) {
-          if (prop_condition.isNull() || svc_data[prop_condition[1].as<int>()] == *prop_condition[2].as<const char*>()) {
+          if (prop_condition.isNull() ||
+              (svc_data && svc_data[prop_condition[1].as<int>()] == *prop_condition[2].as<const char*>()) ||
+              (mfg_data && mfg_data[prop_condition[1].as<int>()] == *prop_condition[2].as<const char*>())) {
             JsonArray decoder = prop["decoder"];
             if (strstr((const char*)decoder[0], "value_from_hex_data") != nullptr) {
               const char* src = svc_data;


### PR DESCRIPTION
## Description:
Previously, manufacturer data was not being considered in the property conditions.
This adds the missing functionality and checks for service data and manufacurer data existance before checking values to prevent exceptions.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
