### PR TITLE
Fix overrun in decodeBLEJson loop and check for valid input data.

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -125,6 +125,12 @@ bool TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
   const char* svc_uuid = jsondata["servicedatauuid"].as<const char*>();
   bool success = false;
 
+  // if there is no data to decode just return
+  if (svc_data == nullptr && mfg_data == nullptr) {
+    DEBUG_PRINT("Invalid data\n");
+    return success;
+  }
+
   /* loop through the devices and attempt to match the input data to a device parameter set */
   for (auto i = 0; i < sizeof(_devices) / sizeof(_devices[0]); ++i) {
     DeserializationError error = deserializeJson(doc, _devices[i][0]);

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -126,7 +126,7 @@ bool TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
   bool success = false;
 
   /* loop through the devices and attempt to match the input data to a device parameter set */
-  for (auto i = 0; i < sizeof(_devices) / sizeof(_devices[0][0]); ++i) {
+  for (auto i = 0; i < sizeof(_devices) / sizeof(_devices[0]); ++i) {
     DeserializationError error = deserializeJson(doc, _devices[i][0]);
     if (error) {
       DEBUG_PRINT("deserializeJson() failed: %s\n", error.c_str());

--- a/tests/BLE_fail/test_ble_fail.cpp
+++ b/tests/BLE_fail/test_ble_fail.cpp
@@ -117,4 +117,13 @@ int main() {
     std::cout << "FAILED! Should fail getTheengProperties returned a value" << std::endl;
     return 1;
   }
+
+  doc.clear();
+  std::cout << "trying garbage inputs" << std::endl;
+  doc["garbage"] = "input";
+  bleObject = doc.as<JsonObject>();
+  if (decoder.decodeBLEJson(bleObject) != false) {
+    std::cout << "FAILED! garbage input returned true" << std::endl;
+    return 1;
+  }
 }


### PR DESCRIPTION
## Description:
Bugfix: the `decodeBLEJson` loop was using the wrong size of the devices array as the limiter.

If the input data does not contain valid "servicedata" or "manufacturerdata", return immediately rather than parsing all the devices. 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
