### PR TITLE
Add more informative test for doc size.

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -34,8 +34,9 @@
 #endif
 
 #ifdef UNIT_TESTING
-#  define ABS_MAX_HEAP 16384
-static uint32_t peakDocSize = 0;
+#  define TEST_MAX_DOC 16384UL
+#  include <assert.h>
+static size_t peakDocSize = 0;
 #endif
 
 /*
@@ -64,7 +65,7 @@ long TheengsDecoder::value_from_hex_string(const char* data_str, int offset, int
   }
 
   long value = strtol(data.c_str(), NULL, 16);
-  DEBUG_PRINT("extracted value from %s = 0x%08x\n", data.c_str(), value);
+  DEBUG_PRINT("extracted value from %s = 0x%08lx\n", data.c_str(), value);
 
   if (canBeNegative) {
     if (data_length <= 2 && value > SCHAR_MAX) {
@@ -124,7 +125,7 @@ int TheengsDecoder::data_length_is_valid(size_t data_len, size_t default_min, Js
  */
 bool TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
 #ifdef UNIT_TESTING
-  DynamicJsonDocument doc(ABS_MAX_HEAP);
+  DynamicJsonDocument doc(TEST_MAX_DOC);
 #else
   DynamicJsonDocument doc(m_docMax);
 #endif
@@ -145,6 +146,9 @@ bool TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
     DeserializationError error = deserializeJson(doc, _devices[i][0]);
     if (error) {
       DEBUG_PRINT("deserializeJson() failed: %s\n", error.c_str());
+#ifdef UNIT_TESTING
+      assert(0);
+#endif
       return success;
     }
 #ifdef UNIT_TESTING
@@ -392,10 +396,13 @@ bool TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
 int TheengsDecoder::getTheengModel(JsonDocument& doc, const char* model_id) {
   int mid_len = strlen(model_id);
 
-  for (auto i = 0; i < sizeof(_devices) / sizeof(_devices[0][0]); ++i) {
+  for (auto i = 0; i < sizeof(_devices) / sizeof(_devices[0]); ++i) {
     DeserializationError error = deserializeJson(doc, _devices[i][0]);
     if (error) {
       DEBUG_PRINT("deserializeJson() failed: %s\n", error.c_str());
+#ifdef UNIT_TESTING
+      assert(0);
+#endif
       break;
     }
 #ifdef UNIT_TESTING
@@ -418,7 +425,7 @@ int TheengsDecoder::getTheengModel(JsonDocument& doc, const char* model_id) {
 
 std::string TheengsDecoder::getTheengProperties(const char* model_id) {
 #ifdef UNIT_TESTING
-  DynamicJsonDocument doc(ABS_MAX_HEAP);
+  DynamicJsonDocument doc(TEST_MAX_DOC);
 #else
   DynamicJsonDocument doc(m_docMax);
 #endif
@@ -428,7 +435,7 @@ std::string TheengsDecoder::getTheengProperties(const char* model_id) {
 
 std::string TheengsDecoder::getTheengAttribute(const char* model_id, const char* attribute) {
 #ifdef UNIT_TESTING
-  DynamicJsonDocument doc(ABS_MAX_HEAP);
+  DynamicJsonDocument doc(TEST_MAX_DOC);
 #else
   DynamicJsonDocument doc(m_docMax);
 #endif
@@ -451,7 +458,7 @@ void TheengsDecoder::setMinManufacturerDataLen(size_t len) {
 #ifdef UNIT_TESTING
 int TheengsDecoder::testDocMax() {
   if (peakDocSize > m_docMax) {
-    DEBUG_PRINT("Error: peak doc size > max; peak: %u, max: %u\n", peakDocSize, m_docMax);
+    DEBUG_PRINT("Error: peak doc size > max; peak: %lu, max: %lu\n", peakDocSize, m_docMax);
   }
   return m_docMax - peakDocSize;
 }

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -38,6 +38,9 @@ public:
   std::string getTheengProperties(const char* model_id);
   std::string getTheengAttribute(const char* model_id, const char* attribute);
   int getTheengModel(JsonDocument& doc, const char* model_id);
+#ifdef UNIT_TESTING
+  int testDocMax();
+#endif
 
 private:
   void reverse_hex_data(const char* in, char* out, int l);

--- a/tests/BLE/CMakeLists.txt
+++ b/tests/BLE/CMakeLists.txt
@@ -8,7 +8,7 @@ target_compile_features(test_ble PRIVATE cxx_std_11)
 
 target_link_libraries(test_ble PUBLIC decoder)
 
-#target_compile_definitions(decoder PRIVATE DEBUG_DECODER)
+target_compile_definitions(decoder PUBLIC DEBUG_DECODER UNIT_TESTING)
 
 target_include_directories(test_ble PUBLIC 
                            "${PROJECT_BINARY_DIR}"

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -297,4 +297,8 @@ int main() {
       return 1;
     }
   }
+
+  if (decoder.testDocMax() < 0) {
+    return 1;
+  }
 }

--- a/tests/BLE_fail/CMakeLists.txt
+++ b/tests/BLE_fail/CMakeLists.txt
@@ -8,8 +8,6 @@ target_compile_features(test_ble_fail PRIVATE cxx_std_11)
 
 target_link_libraries(test_ble_fail PUBLIC decoder)
 
-target_compile_definitions(decoder PRIVATE DEBUG_DECODER)
-
 target_include_directories(test_ble_fail PUBLIC 
                            "${PROJECT_BINARY_DIR}"
                            )

--- a/tests/BLE_fail/test_ble_fail.cpp
+++ b/tests/BLE_fail/test_ble_fail.cpp
@@ -113,7 +113,7 @@ int main() {
     }
   }
 
-  if (!decoder.getTheengProperties("SHOULD_FAIL").empty()){
+  if (!decoder.getTheengProperties("SHOULD_FAIL").empty()) {
     std::cout << "FAILED! Should fail getTheengProperties returned a value" << std::endl;
     return 1;
   }
@@ -124,6 +124,10 @@ int main() {
   bleObject = doc.as<JsonObject>();
   if (decoder.decodeBLEJson(bleObject) != false) {
     std::cout << "FAILED! garbage input returned true" << std::endl;
+    return 1;
+  }
+  
+  if (decoder.testDocMax() < 0) {
     return 1;
   }
 }


### PR DESCRIPTION
## Description:
When unit testing, if there is an error due to the doc size setting it is difficult to determine a correct value, this adds am extra test with a more informative output.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
