### PR TITLE
Fix canBeNegative index in decodeBLEJson

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -198,7 +198,7 @@ bool TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
                                                            decoder[4].as<bool>());
                 } else if (decoder.size() == 6) {
                   temp_val = (double)value_from_hex_string(src, decoder[2].as<int>(), decoder[3].as<int>(),
-                                                           decoder[4].as<bool>(), decoder[6].as<bool>());
+                                                           decoder[4].as<bool>(), decoder[5].as<bool>());
                 }
               } else {
                 break;


### PR DESCRIPTION
## Description:

Fixes an incorrect index of the canBeNegative parameter in ``decodeBLEJson``. This fixes part of https://github.com/theengs/decoder/pull/50.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
