### PR TITLE
Revert #52 and add a failed test case

### DIFF
--- a/src/devices/XMTZC04HM_json.h
+++ b/src/devices/XMTZC04HM_json.h
@@ -1,12 +1,12 @@
 #include "common_props.h"
 
-const char* _XMTZC04HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v1\",\"model_id\":\"XMTZC04HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",100]}}}";
+const char* _XMTZC04HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v1\",\"model_id\":\"XMTZC04HM\",\"condition\":[\"uuid\",\"contain\",\"181d\",\"&\",\"servicedata\",\"index\",0,\"2\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",100]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"Miscale_v1",
    "model_id":"XMTZC04HM",
-   "condition":["uuid", "contain", "181d"],
+   "condition":["uuid", "contain", "181d", "&", "servicedata", "index", 0, "2"],
    "properties":{
       "unit":{
          "condition":["servicedata", 1, "2"],

--- a/src/devices/XMTZC04HM_json.h
+++ b/src/devices/XMTZC04HM_json.h
@@ -1,5 +1,7 @@
 #include "common_props.h"
 
+// A condition is done on the first character = 2 so as to verify if the weight is stabilized, the decoder doesn't decode weights that are not stabilized
+
 const char* _XMTZC04HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v1\",\"model_id\":\"XMTZC04HM\",\"condition\":[\"uuid\",\"contain\",\"181d\",\"&\",\"servicedata\",\"index\",0,\"2\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",100]}}}";
 /*R""""(
 {

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -59,7 +59,6 @@ const char* expected_mfg[] = {
 const char* expected_uuid[] = {
     "{\"brand\":\"Xiaomi\",\"model\":\"Miband\",\"model_id\":\"MiBand\",\"steps\":7842}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v1\",\"model_id\":\"XMTZC04HM\",\"unit\":\"kg\",\"weight\":61.75}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v1\",\"model_id\":\"XMTZC04HM\",\"unit\":\"kg\",\"weight\":55.85}",   
     "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"unit\":\"kg\",\"weight\":72.45,\"impedance\":503}",
     "{\"brand\":\"Mokosmart\",\"model\":\"Beacon\",\"model_id\":\"Mokobeacon\",\"batt\":100,\"x_axis\":-24576,\"y_axis\":-3841,\"z_axis\":-8189}",
     "{\"brand\":\"Mokosmart\",\"model\":\"BeaconX Pro\",\"model_id\":\"MBXPRO\",\"tempc\":27.4,\"tempf\":81.32,\"hum\":49.4,\"volt\":3.247}",
@@ -123,7 +122,6 @@ const char* test_mfgdata[][3] = {
 const char* test_uuid[][4] = {
     {"MiBand", "fee0", "servicedata", "a21e0000"},
     {"Miscale", "0x181d", "servicedata", "223e30b207010708031f"},
-    {"Miscale", "0x181d", "servicedata", "a2a22bb2070103003526"},
     {"Miscale_v2", "0x181b", "servicedata", "0284e5070c170c301df7019a38"},
     {"Mokobeacon", "0xff01", "servicedata", "64000000005085a000f0ffe003"},
     {"MokoXPro", "feab", "servicedata", "70000a011201ee0caf03def14635998a"},

--- a/tests/BLE_fail/test_ble_fail.cpp
+++ b/tests/BLE_fail/test_ble_fail.cpp
@@ -43,7 +43,8 @@ const char* test_mfgdata[][3] = {
 // uuid test input [test name] [uuid] [data source] [data]
 const char* test_uuid[][4] = {
     {"MiBand", "fee0", "servicedata", "a21e0000"},
-    {"SHOULD FAIL", "fa11", "servicedata", "123456789ABCDEF"}};
+    {"SHOULD FAIL", "fa11", "servicedata", "123456789ABCDEF"},
+    {"SHOULD FAIL", "0x181d", "servicedata", "a2a22bb2070103003526"}};
 
 int main() {
   StaticJsonDocument<1024> doc;


### PR DESCRIPTION
## Description:
Revert this PR and add a failed test case, the first bit is used for stability checking of the weight (when the weight on the scale blink it is considered as stabilized)
When the first-bit value isn't 2 the weight is not stabilized.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
