### PR TITLE
Fixed docs devices decoder links

### DIFF
--- a/docs/devices/CGD1.md
+++ b/docs/devices/CGD1.md
@@ -1,6 +1,6 @@
 # Cleargrass CGD1
 
-|Model Id|[CGD1](./../../src/devices/CGD1_json.h)|
+|Model Id|[CGD1](https://github.com/theengs/decoder/blob/development/src/devices/CGD1_json.h)|
 |-|-|
 |Brand|CLEARGRASS|
 |Model|Alarm clock|

--- a/docs/devices/CGDK2.md
+++ b/docs/devices/CGDK2.md
@@ -1,6 +1,6 @@
 # Qingping CGDK2
 
-|Model Id|[CGDK2](./../../src/devices/CGDK2_json.h)|
+|Model Id|[CGDK2](https://github.com/theengs/decoder/blob/development/src/devices/CGDK2_json.h)|
 |-|-|
 |Brand|QINGPING|
 |Model|TH lite|

--- a/docs/devices/CGG1.md
+++ b/docs/devices/CGG1.md
@@ -1,6 +1,6 @@
 # Xiaomi CGG1
 
-|Model Id|[CGG1](./../../src/devices/CGG1_json.h)|
+|Model Id|[CGG1](https://github.com/theengs/decoder/blob/development/src/devices/CGG1_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|Round sensor V1|

--- a/docs/devices/CGH1.md
+++ b/docs/devices/CGH1.md
@@ -1,6 +1,6 @@
 # Qingping CGH1
 
-|Model Id|[CGH1](./../../src/devices/CGH1_json.h)|
+|Model Id|[CGH1](https://github.com/theengs/decoder/blob/development/src/devices/CGH1_json.h)|
 |-|-|
 |Brand|Qingping|
 |Model|Door sensor|

--- a/docs/devices/CGP1W.md
+++ b/docs/devices/CGP1W.md
@@ -1,6 +1,6 @@
 # Cleargrass CGP1W
 
-|Model Id|[CGP1W](./../../src/devices/CGP1W_json.h)|
+|Model Id|[CGP1W](https://github.com/theengs/decoder/blob/development/src/devices/CGP1W_json.h)|
 |-|-|
 |Brand|Cleargrass|
 |Model|CG_THP|

--- a/docs/devices/CGPR1.md
+++ b/docs/devices/CGPR1.md
@@ -1,6 +1,6 @@
 # Qingping CGPR1
 
-|Model Id|[CGPR1](./../../src/devices/CGPR1_json.h)|
+|Model Id|[CGPR1](https://github.com/theengs/decoder/blob/development/src/devices/CGPR1_json.h)|
 |-|-|
 |Brand|Qingping|
 |Model|Motion and Light|

--- a/docs/devices/H5072.md
+++ b/docs/devices/H5072.md
@@ -1,6 +1,6 @@
 # Govee H5072
 
-|Model Id|[H5072](./../../src/devices/H5072_json.h)|
+|Model Id|[H5072](https://github.com/theengs/decoder/blob/development/src/devices/H5072_json.h)|
 |-|-|
 |Brand|Govee|
 |Model|Thermo Hygrometer|

--- a/docs/devices/H5075.md
+++ b/docs/devices/H5075.md
@@ -1,6 +1,6 @@
 # Govee H5075
 
-|Model Id|[H5075](./../../src/devices/H5075_json.h)|
+|Model Id|[H5075](https://github.com/theengs/decoder/blob/development/src/devices/H5075_json.h)|
 |-|-|
 |Brand|Govee|
 |Model|Smart Thermo Hygrometer|

--- a/docs/devices/H5102.md
+++ b/docs/devices/H5102.md
@@ -1,6 +1,6 @@
 # Govee H5102
 
-|Model Id|[H5102](./../../src/devices/H5102_json.h)|
+|Model Id|[H5102](https://github.com/theengs/decoder/blob/development/src/devices/H5102_json.h)|
 |-|-|
 |Brand|Govee|
 |Model|Smart Thermo Hygrometer|

--- a/docs/devices/HHCCJCY01HHCC.md
+++ b/docs/devices/HHCCJCY01HHCC.md
@@ -1,6 +1,6 @@
 # Xiaomi Mi Flora
 
-|Model Id|[HHCCJCY01HHCC](./../../src/devices/HHCCJCY01HHCC_json.h)|
+|Model Id|[HHCCJCY01HHCC](https://github.com/theengs/decoder/blob/development/src/devices/HHCCJCY01HHCC_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|MiFlora|

--- a/docs/devices/IBS_TH1.md
+++ b/docs/devices/IBS_TH1.md
@@ -1,6 +1,6 @@
 # Inkbird TH1
 
-|Model Id|[IBS_TH1](./../../src/devices/IBS_TH1_json.h)|
+|Model Id|[IBS_TH1](https://github.com/theengs/decoder/blob/development/src/devices/IBS_TH1_json.h)|
 |-|-|
 |Brand|Inkbird|
 |Model|Smart Temperature sensor|

--- a/docs/devices/IBS_TH2.md
+++ b/docs/devices/IBS_TH2.md
@@ -1,6 +1,6 @@
 # Inkbird TH2
 
-|Model Id|[IBS_TH2](./../../src/devices/IBS_TH2_json.h)|
+|Model Id|[IBS_TH2](https://github.com/theengs/decoder/blob/development/src/devices/IBS_TH2_json.h)|
 |-|-|
 |Brand|Inkbird|
 |Model|Smart Temperature sensor|

--- a/docs/devices/IBT_2X.md
+++ b/docs/devices/IBT_2X.md
@@ -1,6 +1,6 @@
 # Inkbird 2X BBQ
 
-|Model Id|[IBT_2X](./../../src/devices/IBS_2X_json.h)|
+|Model Id|[IBT_2X](https://github.com/theengs/decoder/blob/development/src/devices/IBS_2X_json.h)|
 |-|-|
 |Brand|Inkbird|
 |Model|BBQ Temperature sensor|

--- a/docs/devices/IBT_4XS.md
+++ b/docs/devices/IBT_4XS.md
@@ -1,6 +1,6 @@
 # Inkbird 4XS BBQ
 
-|Model Id|[IBT_4XS](./../../src/devices/IBS_4XS_json.h)|
+|Model Id|[IBT_4XS](https://github.com/theengs/decoder/blob/development/src/devices/IBS_4XS_json.h)|
 |-|-|
 |Brand|Inkbird|
 |Model|BBQ Temperature sensor|

--- a/docs/devices/IBT_6XS.md
+++ b/docs/devices/IBT_6XS.md
@@ -1,6 +1,6 @@
 # Inkbird 6XS BBQ
 
-|Model Id|[IBT_6XS](./../../src/devices/IBS_6XS_json.h)|
+|Model Id|[IBT_6XS](https://github.com/theengs/decoder/blob/development/src/devices/IBS_6XS_json.h)|
 |-|-|
 |Brand|Inkbird|
 |Model|BBQ Temperature sensor|

--- a/docs/devices/JQJCY01YM.md
+++ b/docs/devices/JQJCY01YM.md
@@ -1,6 +1,6 @@
 # Xiaomi Formaldehyde detector
 
-|Model Id|[JQJCY01YM](./../../src/devices/JQJCY01YM_json.h)|
+|Model Id|[JQJCY01YM](https://github.com/theengs/decoder/blob/development/src/devices/JQJCY01YM_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|Formaldehyde detector|

--- a/docs/devices/LYWSD02.md
+++ b/docs/devices/LYWSD02.md
@@ -1,6 +1,6 @@
 # Xiaomi LYWSD02
 
-|Model Id|[LYWSD02](./../../src/devices/LYWSD02_json.h)|
+|Model Id|[LYWSD02](https://github.com/theengs/decoder/blob/development/src/devices/LYWSD02_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|Cleargrass clock|

--- a/docs/devices/LYWSD03MMC_ATC.md
+++ b/docs/devices/LYWSD03MMC_ATC.md
@@ -1,7 +1,7 @@
 # Xiaomi LYWSD03MMC ATC
 ![LYWSD03MMC](./../img/LYWSD03MMC.png)
 
-|Model Id|[LYWSD03MMC_ATC](./../../src/devices/LYWSD03MMC_ATC_json.h)|
+|Model Id|[LYWSD03MMC_ATC](https://github.com/theengs/decoder/blob/development/src/devices/LYWSD03MMC_ATC_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|Compact Temperature sensor|

--- a/docs/devices/LYWSD03MMC_PVVX.md
+++ b/docs/devices/LYWSD03MMC_PVVX.md
@@ -1,7 +1,7 @@
 # Xiaomi LYWSD03MMC PVVX
 ![LYWSD03MMC](./../img/LYWSD03MMC.png)
 
-|Model Id|[LYWSD03MMC_PVVX](./../../src/devices/LYWSD03MMC_PVVX_json.h)|
+|Model Id|[LYWSD03MMC_PVVX](https://github.com/theengs/decoder/blob/development/src/devices/LYWSD03MMC_PVVX_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|Compact Temperature sensor|

--- a/docs/devices/LYWSDCGQ.md
+++ b/docs/devices/LYWSDCGQ.md
@@ -1,6 +1,6 @@
 # Xiaomi LYWSDCGQ
 
-|Model Id|[LYWSDCGQ](./../../src/devices/LYWSDCGQ_json.h)|
+|Model Id|[LYWSDCGQ](https://github.com/theengs/decoder/blob/development/src/devices/LYWSDCGQ_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|Mi Jia|

--- a/docs/devices/MBXPRO.md
+++ b/docs/devices/MBXPRO.md
@@ -1,6 +1,6 @@
 # MokoSmart Pro
 
-|Model Id|[MBXPRO](./../../src/devices/MBXPRO_json.h)|
+|Model Id|[MBXPRO](https://github.com/theengs/decoder/blob/development/src/devices/MBXPRO_json.h)|
 |-|-|
 |Brand|MOKOSMART|
 |Model|H4|

--- a/docs/devices/MUE4094RT.md
+++ b/docs/devices/MUE4094RT.md
@@ -1,6 +1,6 @@
 # Xiaomi Motion sensor and light
 
-|Model Id|[MUE4094RT](./../../src/devices/MUE4094RT_json.h)|
+|Model Id|[MUE4094RT](https://github.com/theengs/decoder/blob/development/src/devices/MUE4094RT_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|Motion and Light|

--- a/docs/devices/Miband.md
+++ b/docs/devices/Miband.md
@@ -1,6 +1,6 @@
 # Xiaomi Mi Band
 
-|Model Id|[LYWSDCGQ](./../../src/devices/LYWSDCGQ_json.h)|
+|Model Id|[LYWSDCGQ](https://github.com/theengs/decoder/blob/development/src/devices/LYWSDCGQ_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|Mi Band|

--- a/docs/devices/MokoBeacon.md
+++ b/docs/devices/MokoBeacon.md
@@ -1,6 +1,6 @@
 # MokoSmart Beacon
 
-|Model Id|[MokoBeacon](./../../src/devices/MokoBeacon_json.h)|
+|Model Id|[MokoBeacon](https://github.com/theengs/decoder/blob/development/src/devices/MokoBeacon_json.h)|
 |-|-|
 |Brand|MOKOSMART|
 |Model|Beacon|

--- a/docs/devices/TPMS.md
+++ b/docs/devices/TPMS.md
@@ -1,6 +1,6 @@
 # TPMS
 
-|Model Id|[TPMS](./../../src/devices/TPMS_json.h)|
+|Model Id|[TPMS](https://github.com/theengs/decoder/blob/development/src/devices/TPMS_json.h)|
 |-|-|
 |Brand|Generic|
 |Model|Tire pressure monitoring system|

--- a/docs/devices/VEGTRUG.md
+++ b/docs/devices/VEGTRUG.md
@@ -1,6 +1,6 @@
 # VEGTRUG
 
-|Model Id|[VEGTRUG](./../../src/devices/VEGTRUG_json.h)|
+|Model Id|[VEGTRUG](https://github.com/theengs/decoder/blob/development/src/devices/VEGTRUG_json.h)|
 |-|-|
 |Brand|VEGTRUG|
 |Model|VEGTRUG|

--- a/docs/devices/WS02.md
+++ b/docs/devices/WS02.md
@@ -1,6 +1,6 @@
 # WS02 ThermoBeacon
 
-|Model Id|[WS02](./../../src/devices/WS02_json.h)|
+|Model Id|[WS02](https://github.com/theengs/decoder/blob/development/src/devices/WS02_json.h)|
 |-|-|
 |Brand|ThermoBeacon|
 |Model|WS02|

--- a/docs/devices/XMTZC04HM.md
+++ b/docs/devices/XMTZC04HM.md
@@ -1,6 +1,6 @@
 # Xiaomi MiScale V1
 
-|Model Id|[XMTZC04HM](./../../src/devices/XMTZC04HM_json.h)|
+|Model Id|[XMTZC04HM](https://github.com/theengs/decoder/blob/development/src/devices/XMTZC04HM_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|MiScale V1|

--- a/docs/devices/XMTZC05HM.md
+++ b/docs/devices/XMTZC05HM.md
@@ -1,6 +1,6 @@
 # Xiaomi MiScale V2
 
-|Model Id|[XMTZC05HM](./../../src/devices/XMTZC05HM_json.h)|
+|Model Id|[XMTZC05HM](https://github.com/theengs/decoder/blob/development/src/devices/XMTZC05HM_json.h)|
 |-|-|
 |Brand|Xiaomi|
 |Model|MiScale V2|

--- a/docs/devices/iBeacon.md
+++ b/docs/devices/iBeacon.md
@@ -1,6 +1,6 @@
 # iBeacon
 
-|Model Id|[IBEACON](./../../src/devices/IBEACON_json.h)|
+|Model Id|[IBEACON](https://github.com/theengs/decoder/blob/development/src/devices/IBEACON_json.h)|
 |-|-|
 |Brand|Generic|
 |Model|Ibeacon|

--- a/docs/devices/iNode.md
+++ b/docs/devices/iNode.md
@@ -1,6 +1,6 @@
 # iNode INEM
 
-|Model Id|[INEM](./../../src/devices/iNode_json.h)|
+|Model Id|[INEM](https://github.com/theengs/decoder/blob/development/src/devices/iNode_json.h)|
 |-|-|
 |Brand|INODE|
 |Model|INEM|

--- a/docs/use/ESP32.md
+++ b/docs/use/ESP32.md
@@ -1,6 +1,6 @@
 # Using with ESP32
 
-The library includes a BLE decoder [example](./../../examples/ESP32/ScanAndDecode/ScanAndDecode.ino) based on ESP32, you can open the folder [ScanAndDecode](./../../examples/ESP32/ScanAndDecode)  with a platformio environment or directly [ScanAndDecode.ino](./../../examples/ESP32/ScanAndDecode/ScanAndDecode.ino) with an Arduino IDE.
+The library includes a BLE decoder [example](https://github.com/theengs/decoder/blob/development/examples/ESP32/ScanAndDecode/ScanAndDecode.ino) based on ESP32, you can open the folder [ScanAndDecode](https://github.com/theengs/decoder/blob/development/examples/ESP32/ScanAndDecode)  with a platformio environment or directly [ScanAndDecode.ino](https://github.com/theengs/decoder/blob/development/examples/ESP32/ScanAndDecode/ScanAndDecode.ino) with an Arduino IDE.
 
 If Theengs Decoder recognize a device, it will print in the serial output a message like the example below:
 ```

--- a/docs/use/include.md
+++ b/docs/use/include.md
@@ -23,5 +23,5 @@ JsonObject after decoding:
 ```
 
 ::: tip
-If you are using ArduinoJson library with your project (like TheengsDecoder) you may have to align the ArduinoJson build options into TheengDecoder with it. To do so, go to [decoder.h](./../../src/decoder.h) and align the flags with your project. In particular you may have to remove `ARDUINOJSON_USE_LONG_LONG=1`.
+If you are using ArduinoJson library with your project (like TheengsDecoder) you may have to align the ArduinoJson build options into TheengDecoder with it. To do so, go to [decoder.h](https://github.com/theengs/decoder/blob/development/src/decoder.h) and align the flags with your project. In particular you may have to remove `ARDUINOJSON_USE_LONG_LONG=1`.
 :::

--- a/docs/use/python.md
+++ b/docs/use/python.md
@@ -18,7 +18,7 @@ pip install .
 
 `import TheengsDecoder`
 
-The library includes a BLE decoder [example](./../../examples/python/ScanAndDecode.py). To run the example, open the folder [ScanAndDecode](./../../examples/python/ScanAndDecode.py) in a terminal and type 'python ScanAndDecode.py`
+The library includes a BLE decoder [example](https://github.com/theengs/decoder/blob/development/examples/python/ScanAndDecode.py). To run the example, open the folder [ScanAndDecode](https://github.com/theengs/decoder/blob/development/examples/python/ScanAndDecode.py) in a terminal and type 'python ScanAndDecode.py`
 
 If Theengs Decoder recognized a device, it will print a message like the example below, otherwise None.
 ```


### PR DESCRIPTION
Fixed docs devices decoder links by changing the relative links, which only work on the github repository, to absolute links, which also work in the github.io doc pages.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
