### PR TITLE
Add BLE model id enum and return index from decodeBLEJson.

### DIFF
--- a/python/TheengsDecoder/_decoder.cpp
+++ b/python/TheengsDecoder/_decoder.cpp
@@ -21,7 +21,7 @@ static PyObject *decode_BLE(PyObject *self, PyObject *args)
     JsonObject bleObject;
     bleObject = doc.as<JsonObject>();
 
-    if (decoder.decodeBLEJson(bleObject)) {
+    if (decoder.decodeBLEJson(bleObject) >= 0) {
       std::string buf;
       bleObject.remove("servicedata");
       bleObject.remove("manufacturerdata");

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -429,6 +429,10 @@ int TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
   return success;
 }
 
+std::string TheengsDecoder::getTheengProperties(int mod_index) {
+  return mod_index < 0 ? "" : _devices[mod_index][1];
+}
+
 int TheengsDecoder::getTheengModel(JsonDocument& doc, const char* model_id) {
   int mid_len = strlen(model_id);
 
@@ -467,6 +471,28 @@ std::string TheengsDecoder::getTheengProperties(const char* model_id) {
 #endif
   int mod_index = getTheengModel(doc, model_id);
   return mod_index < 0 ? "" : _devices[mod_index][1];
+}
+
+std::string TheengsDecoder::getTheengAttribute(int model_id, const char* attribute) {
+#ifdef UNIT_TESTING
+  DynamicJsonDocument doc(TEST_MAX_DOC);
+#else
+  DynamicJsonDocument doc(m_docMax);
+#endif
+  std::string ret_attr = "";
+  if (model_id >= 0 && model_id < sizeof(_devices) / sizeof(_devices[0])) {
+    DeserializationError error = deserializeJson(doc, _devices[model_id][0]);
+    if (error) {
+      DEBUG_PRINT("deserializeJson() failed: %s\n", error.c_str());
+#ifdef UNIT_TESTING
+      assert(0);
+#endif
+    } else if (!doc[attribute].isNull()) {
+      ret_attr = doc[attribute].as<std::string>();
+    }
+  }
+
+  return ret_attr;
 }
 
 std::string TheengsDecoder::getTheengAttribute(const char* model_id, const char* attribute) {

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -429,10 +429,6 @@ int TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
   return success;
 }
 
-std::string TheengsDecoder::getTheengProperties(int mod_index) {
-  return mod_index < 0 ? "" : _devices[mod_index][1];
-}
-
 int TheengsDecoder::getTheengModel(JsonDocument& doc, const char* model_id) {
   int mid_len = strlen(model_id);
 
@@ -461,6 +457,10 @@ int TheengsDecoder::getTheengModel(JsonDocument& doc, const char* model_id) {
   }
 
   return -1;
+}
+
+std::string TheengsDecoder::getTheengProperties(int mod_index) {
+  return mod_index < 0 ? "" : _devices[mod_index][1];
 }
 
 std::string TheengsDecoder::getTheengProperties(const char* model_id) {

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -78,6 +78,7 @@ public:
     MOKOBEACONXPRO,
     INODE_EM,
     IBT_2X,
+    RUUVITAG_RAWV1,
   };
 
 private:

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -32,7 +32,7 @@ public:
   TheengsDecoder() {}
   ~TheengsDecoder() {}
 
-  bool decodeBLEJson(JsonObject& jsondata);
+  int decodeBLEJson(JsonObject& jsondata);
   void setMinServiceDataLen(size_t len);
   void setMinManufacturerDataLen(size_t len);
   std::string getTheengProperties(const char* model_id);
@@ -41,6 +41,42 @@ public:
 #ifdef UNIT_TESTING
   int testDocMax();
 #endif
+
+  enum BLE_ID_NUM {
+    UNKNOWN_MODEL = -1,
+    HHCCJCY01HHCC = 0,
+    VEGTRUG,
+    LYWSD02,
+    LYWSDCGQ,
+    CGP1W,
+    CGG1_V1,
+    CGG1_V2,
+    CGD1,
+    CGDK2,
+    CGH1,
+    JQJCY01YM,
+    IBSTH1,
+    IBSTH2,
+    IBT4XS,
+    IBT6XS,
+    MIBAND,
+    XMTZC04HM,
+    XMTZC05HM,
+    TPMS,
+    LYWSD03MMC_ATC,
+    CGPR1,
+    IBEACON,
+    WS02,
+    H5075,
+    H5072,
+    H5102,
+    LYWSD03MMC_PVVX,
+    MUE4094RT,
+    MOKOBEACON,
+    MOKOBEACONXPRO,
+    INODE_EM,
+    IBT_2X,
+  };
 
 private:
   void reverse_hex_data(const char* in, char* out, int l);

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -36,7 +36,9 @@ public:
   void setMinServiceDataLen(size_t len);
   void setMinManufacturerDataLen(size_t len);
   std::string getTheengProperties(const char* model_id);
+  std::string getTheengProperties(int mod_index);
   std::string getTheengAttribute(const char* model_id, const char* attribute);
+  std::string getTheengAttribute(int model_id, const char* attribute);
   int getTheengModel(JsonDocument& doc, const char* model_id);
 #ifdef UNIT_TESTING
   int testDocMax();

--- a/src/devices.h
+++ b/src/devices.h
@@ -52,7 +52,6 @@
 #include "devices/iBeacon_json.h"
 #include "devices/iNode_json.h"
 
-
 const char* _devices[][2] = {
     {_HHCCJCY01HHCC_json, _HHCCJCY01HHCC_json_props},
     {_VEGTRUG_json, _VEGTRUG_json_props},

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -228,7 +228,7 @@ bool checkResult(JsonObject result, JsonObject expected) {
 }
 
 int main() {
-  StaticJsonDocument<1024> doc;
+  StaticJsonDocument<2048> doc;
   JsonObject bleObject;
   TheengsDecoder decoder;
   int decode_res = -1;

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -174,6 +174,9 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
   TheengsDecoder::BLE_ID_NUM::INODE_EM,
   TheengsDecoder::BLE_ID_NUM::IBT_2X,
   TheengsDecoder::BLE_ID_NUM::IBT6XS,
+  TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV1,
+  TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV1,
+  TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV1,
 };
 
 // uuid test input [test name] [uuid] [data source] [data]

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -102,6 +102,40 @@ const char* test_servicedata[][2] = {
     {"Qingping Motion & Light", "0812443660342d580201530f0118090400000000"},
 };
 
+TheengsDecoder::BLE_ID_NUM test_svcdata_id_num[]{
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+  TheengsDecoder::BLE_ID_NUM::LYWSD02,
+  TheengsDecoder::BLE_ID_NUM::LYWSD02,
+  TheengsDecoder::BLE_ID_NUM::LYWSD02,
+  TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
+  TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
+  TheengsDecoder::BLE_ID_NUM::CGP1W,
+  TheengsDecoder::BLE_ID_NUM::CGP1W,
+  TheengsDecoder::BLE_ID_NUM::CGP1W,
+  TheengsDecoder::BLE_ID_NUM::CGG1_V2,
+  TheengsDecoder::BLE_ID_NUM::CGG1_V2,
+  TheengsDecoder::BLE_ID_NUM::CGG1_V1,
+  TheengsDecoder::BLE_ID_NUM::CGG1_V1,
+  TheengsDecoder::BLE_ID_NUM::CGG1_V1,
+  TheengsDecoder::BLE_ID_NUM::CGD1,
+  TheengsDecoder::BLE_ID_NUM::CGD1,
+  TheengsDecoder::BLE_ID_NUM::CGD1,
+  TheengsDecoder::BLE_ID_NUM::CGDK2,
+  TheengsDecoder::BLE_ID_NUM::CGDK2,
+  TheengsDecoder::BLE_ID_NUM::CGH1,
+  TheengsDecoder::BLE_ID_NUM::CGH1,
+  TheengsDecoder::BLE_ID_NUM::CGH1,
+  TheengsDecoder::BLE_ID_NUM::CGH1,
+  TheengsDecoder::BLE_ID_NUM::JQJCY01YM,
+  TheengsDecoder::BLE_ID_NUM::JQJCY01YM,
+  TheengsDecoder::BLE_ID_NUM::JQJCY01YM,
+  TheengsDecoder::BLE_ID_NUM::LYWSD03MMC_ATC,
+  TheengsDecoder::BLE_ID_NUM::CGPR1,
+};
+
 // manufacturer data test input [test name] [device name] [data]
 const char* test_mfgdata[][3] = {
     {"Inkbird TH1", "sps", "660a03150110805908"},
@@ -124,6 +158,24 @@ const char* test_mfgdata[][3] = {
     {"RuuviTag RAWv1", "RuuviTag minimum values", "99040300FF6300008001800180010000"},
 };
 
+TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
+  TheengsDecoder::BLE_ID_NUM::IBSTH1,
+  TheengsDecoder::BLE_ID_NUM::TPMS,
+  TheengsDecoder::BLE_ID_NUM::IBEACON,
+  TheengsDecoder::BLE_ID_NUM::IBEACON,
+  TheengsDecoder::BLE_ID_NUM::WS02,
+  TheengsDecoder::BLE_ID_NUM::H5075,
+  TheengsDecoder::BLE_ID_NUM::H5072,
+  TheengsDecoder::BLE_ID_NUM::H5102,
+  TheengsDecoder::BLE_ID_NUM::IBT4XS,
+  TheengsDecoder::BLE_ID_NUM::IBSTH2,
+  TheengsDecoder::BLE_ID_NUM::IBSTH2,
+  TheengsDecoder::BLE_ID_NUM::INODE_EM,
+  TheengsDecoder::BLE_ID_NUM::INODE_EM,
+  TheengsDecoder::BLE_ID_NUM::IBT_2X,
+  TheengsDecoder::BLE_ID_NUM::IBT6XS,
+};
+
 // uuid test input [test name] [uuid] [data source] [data]
 const char* test_uuid[][4] = {
     {"MiBand", "fee0", "servicedata", "a21e0000"},
@@ -131,6 +183,14 @@ const char* test_uuid[][4] = {
     {"Miscale_v2", "0x181b", "servicedata", "0284e5070c170c301df7019a38"},
     {"Mokobeacon", "0xff01", "servicedata", "64000000005085a000f0ffe003"},
     {"MokoXPro", "feab", "servicedata", "70000a011201ee0caf03def14635998a"},
+};
+
+TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
+  TheengsDecoder::BLE_ID_NUM::MIBAND,
+  TheengsDecoder::BLE_ID_NUM::XMTZC04HM,
+  TheengsDecoder::BLE_ID_NUM::XMTZC05HM,
+  TheengsDecoder::BLE_ID_NUM::MOKOBEACON,
+  TheengsDecoder::BLE_ID_NUM::MOKOBEACONXPRO,
 };
 
 template <typename T>
@@ -167,8 +227,8 @@ bool checkResult(JsonObject result, JsonObject expected) {
 int main() {
   StaticJsonDocument<1024> doc;
   JsonObject bleObject;
-
   TheengsDecoder decoder;
+  int decode_res = -1;
 
   for (unsigned int i = 0; i < sizeof(test_servicedata) / sizeof(test_servicedata[0]); ++i) {
     doc.clear();
@@ -176,8 +236,9 @@ int main() {
     doc["servicedata"] = test_servicedata[i][1];
     bleObject = doc.as<JsonObject>();
 
-    if (decoder.decodeBLEJson(bleObject)) {
-      std::cout << "Found : ";
+    decode_res = decoder.decodeBLEJson(bleObject);
+    if (decode_res == test_svcdata_id_num[i]) {
+      std::cout << "Found : " << decode_res << " ";
       bleObject.remove("servicedata");
       serializeJson(doc, std::cout);
       std::cout << std::endl;
@@ -220,8 +281,9 @@ int main() {
     doc["manufacturerdata"] = test_mfgdata[i][2];
     bleObject = doc.as<JsonObject>();
 
-    if (decoder.decodeBLEJson(bleObject)) {
-      std::cout << "Found : ";
+    decode_res = decoder.decodeBLEJson(bleObject);
+    if (decode_res == test_mfgdata_id_num[i]) {
+      std::cout << "Found : " << decode_res << " ";
       bleObject.remove("name");
       bleObject.remove("manufacturerdata");
       serializeJson(doc, std::cout);
@@ -265,8 +327,9 @@ int main() {
     doc["servicedatauuid"] = test_uuid[i][1];
     bleObject = doc.as<JsonObject>();
 
-    if (decoder.decodeBLEJson(bleObject)) {
-      std::cout << "Found : ";
+    decode_res = decoder.decodeBLEJson(bleObject);
+    if (decode_res == test_uuid_id_num[i]) {
+      std::cout << "Found : " << decode_res << " ";
       bleObject.remove("servicedatauuid");
       bleObject.remove(test_uuid[i][2]);
       serializeJson(doc, std::cout);

--- a/tests/BLE_fail/test_ble_fail.cpp
+++ b/tests/BLE_fail/test_ble_fail.cpp
@@ -33,23 +33,70 @@ const char* test_servicedata[][2] = {
     {"Formaldehyde detector", "5020df02383a5c014357480a10015e"},
     {"Formaldehyde detector", "5020df02283a5c014357480610025302"},
     {"Formaldehyde detector", "5020df025b3a5c014357481010020800"},
-    {"SHOULD FAIL", "0c01810207024d270201508094c0140342d5801040"}};
+    {"SHOULD FAIL", "0c01810207024d270201508094c0140342d5801040"}
+};
+
+TheengsDecoder::BLE_ID_NUM test_svcdata_id_num[]{
+    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+    TheengsDecoder::BLE_ID_NUM::LYWSD02,
+    TheengsDecoder::BLE_ID_NUM::LYWSD02,
+    TheengsDecoder::BLE_ID_NUM::LYWSD02,
+    TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
+    TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
+    TheengsDecoder::BLE_ID_NUM::CGP1W,
+    TheengsDecoder::BLE_ID_NUM::CGP1W,
+    TheengsDecoder::BLE_ID_NUM::CGP1W,
+    TheengsDecoder::BLE_ID_NUM::CGG1_V2,
+    TheengsDecoder::BLE_ID_NUM::CGG1_V2,
+    TheengsDecoder::BLE_ID_NUM::CGG1_V1,
+    TheengsDecoder::BLE_ID_NUM::CGG1_V1,
+    TheengsDecoder::BLE_ID_NUM::CGG1_V1,
+    TheengsDecoder::BLE_ID_NUM::CGD1,
+    TheengsDecoder::BLE_ID_NUM::CGD1,
+    TheengsDecoder::BLE_ID_NUM::CGD1,
+    TheengsDecoder::BLE_ID_NUM::CGDK2,
+    TheengsDecoder::BLE_ID_NUM::CGDK2,
+    TheengsDecoder::BLE_ID_NUM::CGH1,
+    TheengsDecoder::BLE_ID_NUM::CGH1,
+    TheengsDecoder::BLE_ID_NUM::CGH1,
+    TheengsDecoder::BLE_ID_NUM::CGH1,
+    TheengsDecoder::BLE_ID_NUM::JQJCY01YM,
+    TheengsDecoder::BLE_ID_NUM::JQJCY01YM,
+    TheengsDecoder::BLE_ID_NUM::JQJCY01YM,
+    TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL,
+};
 
 // manufacturer data test input [test name] [device name] [data]
 const char* test_mfgdata[][3] = {
     {"Inkbird TH1", "sps", "660a03150110805908"},
-    {"SHOULD FAIL", "fail", "270201508094c014"}};
+    {"SHOULD FAIL", "fail", "270201508094c014"}
+};
+
+TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
+    TheengsDecoder::BLE_ID_NUM::IBSTH1,
+    TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL,
+};
 
 // uuid test input [test name] [uuid] [data source] [data]
 const char* test_uuid[][4] = {
     {"MiBand", "fee0", "servicedata", "a21e0000"},
     {"SHOULD FAIL", "fa11", "servicedata", "123456789ABCDEF"},
-    {"SHOULD FAIL", "0x181d", "servicedata", "a2a22bb2070103003526"}};
+    {"SHOULD FAIL", "0x181d", "servicedata", "a2a22bb2070103003526"}
+};
 
+TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
+    TheengsDecoder::BLE_ID_NUM::MIBAND,
+    TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL,
+    TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL,
+};
 int main() {
   StaticJsonDocument<1024> doc;
   JsonObject bleObject;
   TheengsDecoder decoder;
+  int decode_res = -1;
 
   for (unsigned int i = 0; i < sizeof(test_servicedata) / sizeof(test_servicedata[0]); ++i) {
     doc.clear();
@@ -57,7 +104,8 @@ int main() {
     doc["servicedata"] = test_servicedata[i][1];
     bleObject = doc.as<JsonObject>();
 
-    if (decoder.decodeBLEJson(bleObject)) {
+    decode_res = decoder.decodeBLEJson(bleObject);
+    if (decode_res == test_svcdata_id_num[i]) {
       std::cout << "Found : ";
       bleObject.remove("servicedata");
       serializeJson(doc, std::cout);
@@ -77,7 +125,8 @@ int main() {
     doc["manufacturerdata"] = test_mfgdata[i][2];
     bleObject = doc.as<JsonObject>();
 
-    if (decoder.decodeBLEJson(bleObject)) {
+    decode_res = decoder.decodeBLEJson(bleObject);
+    if (decode_res == test_mfgdata_id_num[i]) {
       std::cout << "Found : ";
       bleObject.remove("name");
       bleObject.remove("manufacturerdata");
@@ -98,7 +147,8 @@ int main() {
     doc["servicedatauuid"] = test_uuid[i][1];
     bleObject = doc.as<JsonObject>();
 
-    if (decoder.decodeBLEJson(bleObject)) {
+    decode_res = decoder.decodeBLEJson(bleObject);
+    if (decode_res == test_uuid_id_num[i]) {
       std::cout << "Found : ";
       bleObject.remove("servicedatauuid");
       bleObject.remove(test_uuid[i][2]);
@@ -123,11 +173,12 @@ int main() {
   std::cout << "trying garbage inputs" << std::endl;
   doc["garbage"] = "input";
   bleObject = doc.as<JsonObject>();
-  if (decoder.decodeBLEJson(bleObject) != false) {
-    std::cout << "FAILED! garbage input returned true" << std::endl;
+  decode_res = decoder.decodeBLEJson(bleObject);
+  if (decode_res >= 0) {
+    std::cout << "FAILED! garbage input returned " << decode_res << std::endl;
     return 1;
   }
-  
+
   if (decoder.testDocMax() < 0) {
     return 1;
   }

--- a/tests/BLE_fail/test_ble_fail.cpp
+++ b/tests/BLE_fail/test_ble_fail.cpp
@@ -93,7 +93,7 @@ TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
     TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL,
 };
 int main() {
-  StaticJsonDocument<1024> doc;
+  StaticJsonDocument<2048> doc;
   JsonObject bleObject;
   TheengsDecoder decoder;
   int decode_res = -1;


### PR DESCRIPTION
## Description:
This adds an enum to allow the calling fuction to determine the model found from the value returned by decodeBLEJson.

Also added new overload methods for getTheengAttribute and getTheengProperties. These new methods take an `int model_id` instead of `const char*` the model id should correspond to the enum id returned by decodeBLEJson.

### Breaking:
This changes the return value from `decodeBLEJson`, from `bool` to `int` which will return values less than 0 when the decoding is not successful.  


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
