### PR TITLE
Add RuuviTag RAWv2 decoder

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -46,6 +46,7 @@ module.exports = {
             'devices/CGH1',
             'devices/CGPR1',
             'devices/RuuviTag_RAWv1',
+            'devices/RuuviTag_RAWv2',
             'devices/TPMS',
             'devices/VEGTRUG',
             'devices/WS02',

--- a/docs/devices/RuuviTag_RAWv2.md
+++ b/docs/devices/RuuviTag_RAWv2.md
@@ -1,0 +1,12 @@
+# RuuviTag (RAWv2 data format)
+
+|Model Id|[RuuviTag_RAWv2](https://github.com/theengs/decoder/blob/development/src/devices/RuuviTag_RAWv2_json.h)|
+|-|-|
+|Brand|Ruuvi|
+|Model|RuuviTag|
+|Short Description| Open source environmental sensor|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|CR2477|
+|Exchanged data|temperature, humidity, pressure, acceleration, voltage, TX power, movement counter, measurement sequence number|
+|Encrypted|No|

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -79,6 +79,7 @@ public:
     INODE_EM,
     IBT_2X,
     RUUVITAG_RAWV1,
+    RUUVITAG_RAWV2,
   };
 
 private:

--- a/src/devices.h
+++ b/src/devices.h
@@ -44,6 +44,7 @@
 #include "devices/Miband_json.h"
 #include "devices/Mokobeacon_json.h"
 #include "devices/RuuviTag_RAWv1_json.h"
+#include "devices/RuuviTag_RAWv2_json.h"
 #include "devices/TPMS_json.h"
 #include "devices/VEGTRUG_json.h"
 #include "devices/WS02_json.h"
@@ -86,4 +87,5 @@ const char* _devices[][2] = {
     {_iNode_json, _iNode_json_props},
     {_IBT_2X_json, _IBT_2X_json_props},
     {_RuuviTag_RAWv1_json, _RuuviTag_RAWv1_json_props},
+    {_RuuviTag_RAWv2_json, _RuuviTag_RAWv2_json_props},
 };

--- a/src/devices/RuuviTag_RAWv2_json.h
+++ b/src/devices/RuuviTag_RAWv2_json.h
@@ -1,0 +1,95 @@
+const char* _RuuviTag_RAWv2_json = "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"condition\":[\"manufacturerdata\",\"=\",52,\"index\",0,\"990405\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",6,4,false,true],\"post_proc\":[\"/\",200]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,4,false,false],\"post_proc\":[\"/\",400]},\"pres\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,false,false],\"post_proc\":[\"+\",50000,\"/\",100]},\"accx\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,false,true],\"post_proc\":[\"/\",1000]},\"accy\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",22,4,false,true],\"post_proc\":[\"/\",1000]},\"accz\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",26,4,false,true],\"post_proc\":[\"/\",1000]},\"volt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",30,4,false,false],\"post_proc\":[\">\",5,\"+\",1600,\"/\",1000]},\"tx\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",30,4,false,false],\"post_proc\":[\"%\",32,\"*\",2,\"-\",40]},\"mov\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",34,2,false,false]},\"seq\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,4,false,false]}}}";
+/*R""""(
+{
+   "brand":"Ruuvi",
+   "model":"RuuviTag",
+   "model_id":"RuuviTag_RAWv2",
+   "condition":["manufacturerdata", "=", 52, "index", 0, "990405"],
+   "properties":{
+      "tempc":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 6, 4, false, true],
+         "post_proc":["/", 200]
+      },
+      "hum":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 10, 4, false, false],
+         "post_proc":["/", 400]
+      },
+      "pres":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 14, 4, false, false],
+         "post_proc":["+", 50000, "/", 100]
+      },
+      "accx":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 18, 4, false, true],
+         "post_proc":["/", 1000]
+      },
+      "accy":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 22, 4, false, true],
+         "post_proc":["/", 1000]
+      },
+      "accz":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 26, 4, false, true],
+         "post_proc":["/", 1000]
+      },
+      "volt":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 30, 4, false, false],
+         "post_proc":[">", 5, "+", 1600, "/", 1000]
+      },
+      "tx":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 30, 4, false, false],
+         "post_proc":["%", 32, "*", 2, "-", 40]
+      },
+      "mov":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 34, 2, false, false]
+      },
+      "seq":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 36, 4, false, false]
+      }
+   }
+})"""";*/
+
+const char* _RuuviTag_RAWv2_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"hPa\",\"name\":\"pressure\"},\"accx\":{\"unit\":\"g\",\"name\":\"accelerationX\"},\"accy\":{\"unit\":\"g\",\"name\":\"accelerationY\"},\"accz\":{\"unit\":\"g\",\"name\":\"accelerationZ\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"},\"tx\":{\"unit\":\"dBm\",\"name\":\"TX power\"},\"mov\":{\"unit\":\"int\",\"name\":\"movement counter\"},\"seq\":{\"unit\":\"int\",\"name\":\"measurement sequence number\"}}}";
+/*R""""(
+{
+   "properties":{
+      "hum":{
+         "unit":"%",
+         "name":"humidity"
+      },
+      "tempc":{
+         "unit":"°C",
+         "name":"temperature"
+      },
+      "pres":{
+         "unit":"hPa",
+         "name":"pressure"
+      },
+      "accx":{
+         "unit":"g",
+         "name":"accelerationX"
+      },
+      "accy":{
+         "unit":"g",
+         "name":"accelerationY"
+      },
+      "accz":{
+         "unit":"g",
+         "name":"accelerationZ"
+      },
+      "volt":{
+         "unit":"V",
+         "name":"voltage"
+      },
+      "tx":{
+         "unit":"dBm",
+         "name":"TX power"
+      },
+      "mov":{
+         "unit":"int",
+         "name":"movement counter"
+      },
+      "seq":{
+         "unit":"int",
+         "name":"measurement sequence number"
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -57,6 +57,9 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv1\",\"hum\":20.5,\"tempc\":26.3,\"tempf\":79.34,\"pres\":1027.66,\"accx\":-1,\"accy\":-1.726,\"accz\":0.714,\"volt\":2.899}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv1\",\"hum\":127.5,\"tempc\":127.99,\"tempf\":262.382,\"pres\":1155.35,\"accx\":32.767,\"accy\":32.767,\"accz\":32.767,\"volt\":65.535}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv1\",\"hum\":0,\"tempc\":-127.99,\"tempf\":-198.382,\"pres\":500,\"accx\":-32.767,\"accy\":-32.767,\"accz\":-32.767,\"volt\":0}",
+    "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":24.3,\"tempf\":75.74,\"hum\":53.49,\"pres\":1000.44,\"accx\":0.004,\"accy\":-0.004,\"accz\":1.036,\"volt\":2.977,\"tx\":4,\"mov\":66,\"seq\":205}",
+    "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":163.835,\"tempf\":326.903,\"hum\":163.8350,\"pres\":1155.34,\"accx\":32.767,\"accy\":32.767,\"accz\":32.767,\"volt\":3.646,\"tx\":20,\"mov\":254,\"seq\":65534}",
+    "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":-163.835,\"tempf\":-262.903,\"hum\":0,\"pres\":500,\"accx\":-32.767,\"accy\":-32.767,\"accz\":-32.767,\"volt\":1.6,\"tx\":-40,\"mov\":0,\"seq\":0}",
 };
 
 const char* expected_uuid[] = {
@@ -156,6 +159,9 @@ const char* test_mfgdata[][3] = {
     {"RuuviTag RAWv1", "RuuviTag", "990403291A1ECE1EFC18F94202CA0B53"},
     {"RuuviTag RAWv1", "RuuviTag maximum values", "990403FF7F63FFFF7FFF7FFF7FFFFFFF"},
     {"RuuviTag RAWv1", "RuuviTag minimum values", "99040300FF6300008001800180010000"},
+    {"RuuviTag RAWv2", "RuuviTag", "99040512FC5394C37C0004FFFC040CAC364200CDCBB8334C884F"},
+    {"RuuviTag RAWv2", "RuuviTag maximum values", "9904057FFFFFFEFFFE7FFF7FFF7FFFFFDEFEFFFECBB8334C884F"},
+    {"RuuviTag RAWv2", "RuuviTag minimum values", "9904058001000000008001800180010000000000CBB8334C884F"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
@@ -177,6 +183,9 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
   TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV1,
   TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV1,
   TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV1,
+  TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2,
+  TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2,
+  TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2,
 };
 
 // uuid test input [test name] [uuid] [data source] [data]
@@ -246,7 +255,7 @@ int main() {
       serializeJson(doc, std::cout);
       std::cout << std::endl;
 
-      StaticJsonDocument<1024> doc_exp;
+      StaticJsonDocument<2048> doc_exp;
       JsonObject expected = doc_exp.to<JsonObject>();
       deserializeJson(doc_exp, expected_servicedata[i]);
 
@@ -292,7 +301,7 @@ int main() {
       serializeJson(doc, std::cout);
       std::cout << std::endl;
 
-      StaticJsonDocument<1024> doc_exp;
+      StaticJsonDocument<2048> doc_exp;
       JsonObject expected = doc_exp.to<JsonObject>();
       deserializeJson(doc_exp, expected_mfg[i]);
 
@@ -338,7 +347,7 @@ int main() {
       serializeJson(doc, std::cout);
       std::cout << std::endl;
 
-      StaticJsonDocument<1024> doc_exp;
+      StaticJsonDocument<2048> doc_exp;
       JsonObject expected = doc_exp.to<JsonObject>();
       deserializeJson(doc_exp, expected_uuid[i]);
 


### PR DESCRIPTION
## Description:

This adds a decoder for the [RuuviTag RAWv2](https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2) data format.

I added the [official test vectors](https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2#test-vectors) to the tests.

The test fails with `deserializeJson() failed: NoMemory`... If I change all instances of `StaticJsonDocument<1024>` to `StaticJsonDocument<2048>` in `tests/BLE/test_ble.cpp`, the tests pass. Should I do another PR for this change?

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
