### PR TITLE
Add BlueMaestro TempoDisc V23

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -29,6 +29,7 @@ module.exports = {
           title: '1 - Devices 🌡️',   // required
           sidebarDepth: 1,    // optional, defaults to 1
           children: [
+            'devices/BM_V23',
             'devices/CGD1',
             'devices/CGP1W',
             'devices/H5072',

--- a/docs/devices/BM_V23.md
+++ b/docs/devices/BM_V23.md
@@ -1,0 +1,12 @@
+# Blue Maestro TempoDisc
+
+|Model Id|[BM_V23](https://github.com/theengs/decoder/blob/development/src/devices/BM_V23_json.h)|
+|-|-|
+|Brand|BlueMaestro|
+|Model|TempoDisc|
+|Short Description|Temperature, humidity and due point with voltage, IP42|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|CR2032|
+|Exchanged data|temperature, humidity, duepoint, voltage|
+|Encrypted|No|

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -81,6 +81,7 @@ public:
     IBT_2X,
     RUUVITAG_RAWV1,
     RUUVITAG_RAWV2,
+    BM_V23,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -53,6 +53,7 @@
 #include "devices/XMTZC05HM_json.h"
 #include "devices/iBeacon_json.h"
 #include "devices/iNode_json.h"
+#include "devices/BM_V23_json.h"
 
 const char* _devices[][2] = {
     {_HHCCJCY01HHCC_json, _HHCCJCY01HHCC_json_props},
@@ -90,4 +91,5 @@ const char* _devices[][2] = {
     {_IBT_2X_json, _IBT_2X_json_props},
     {_RuuviTag_RAWv1_json, _RuuviTag_RAWv1_json_props},
     {_RuuviTag_RAWv2_json, _RuuviTag_RAWv2_json_props},
+    {_BM_V23_json, _BM_V23_json_props},
 };

--- a/src/devices/BM_V23_json.h
+++ b/src/devices/BM_V23_json.h
@@ -1,0 +1,52 @@
+#include "common_props.h"
+
+const char* _BM_V23_json = "{\"brand\":\"BlueMaestro\",\"model\":\"TempoDisc\",\"model_id\":\"BM_V23\",\"condition\":[\"manufacturerdata\",\"=\",32,\"index\",0,\"3301\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4],\"post_proc\":[\"/\",10]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4],\"post_proc\":[\"/\",10]},\"dp\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4],\"post_proc\":[\"/\",10]},\"volt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4],\"post_proc\":[\"/\",100]}}}";
+
+/*R""""(
+{
+   "brand":"BlueMaestro",
+   "model":"TempoDisc",
+   "model_id":"BM_V23",
+   "condition":["manufacturerdata","=",32, "index", 0, "3301"],
+   "properties":{
+      "tempc":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 16, 4],
+         "post_proc":["/", 10]
+      },
+      "hum":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 20, 4],
+         "post_proc":["/", 10]
+      },
+      "tempc2":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 24, 4],
+         "post_proc":["/", 10]
+      },
+      "volt":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 28, 4],
+         "post_proc":["/", 100]
+      }
+   }
+})"""";*/
+
+const char* _BM_V23_json_props = "{\"properties\":{\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"dp\":{\"unit\":\"°C\",\"name\":\"dueppoint\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"}}}";
+/*R""""(
+{
+	"properties": {
+		"volt": {
+			"unit": "V",
+			"name": "voltage"
+		},
+		"tempc": {
+			"unit": "°C",
+			"name": "temperature"
+		},
+		"dp": {
+			"unit": "°C",
+			"name": "duepoint"
+		},
+		"hum": {
+			"unit": "%",
+			"name": "humidity"
+		}
+	}
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -61,6 +61,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":24.3,\"tempf\":75.74,\"hum\":53.49,\"pres\":1000.44,\"accx\":0.004,\"accy\":-0.004,\"accz\":1.036,\"volt\":2.977,\"tx\":4,\"mov\":66,\"seq\":205}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":163.835,\"tempf\":326.903,\"hum\":163.8350,\"pres\":1155.34,\"accx\":32.767,\"accy\":32.767,\"accz\":32.767,\"volt\":3.646,\"tx\":20,\"mov\":254,\"seq\":65534}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":-163.835,\"tempf\":-262.903,\"hum\":0,\"pres\":500,\"accx\":-32.767,\"accy\":-32.767,\"accz\":-32.767,\"volt\":1.6,\"tx\":-40,\"mov\":0,\"seq\":0}",
+    "{\"brand\":\"BlueMaestro\",\"model\":\"TempoDisc\",\"model_id\":\"BM_V23\",\"tempc\":23.9,\"tempf\":75.02,\"dp\":10.8,\"hum\":43.5,\"volt\":2.56}",
 };
 
 const char* expected_uuid[] = {
@@ -164,6 +165,7 @@ const char* test_mfgdata[][3] = {
     {"RuuviTag RAWv2", "RuuviTag", "99040512FC5394C37C0004FFFC040CAC364200CDCBB8334C884F"},
     {"RuuviTag RAWv2", "RuuviTag maximum values", "9904057FFFFFFEFFFE7FFF7FFF7FFFFFDEFEFFFECBB8334C884F"},
     {"RuuviTag RAWv2", "RuuviTag minimum values", "9904058001000000008001800180010000000000CBB8334C884F"},
+    {"BM_V23", "V23", "330117560e10177000ef01b3006c0100"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
@@ -189,6 +191,7 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
   TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2,
   TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2,
   TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2,
+  TheengsDecoder::BLE_ID_NUM::BM_V23,
 };
 
 // uuid test input [test name] [uuid] [data source] [data]


### PR DESCRIPTION
## Description:
Add small blue beacon from BlueMaestro with temperature, humidity, dewpoint and battery voltage measurement

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
