### PR TITLE
Universal XMTZC04HM decoder

### DIFF
--- a/src/devices/XMTZC04HM_json.h
+++ b/src/devices/XMTZC04HM_json.h
@@ -2,13 +2,13 @@
 
 // A condition is done on the first character = 2 so as to verify if the weight is stabilized, the decoder doesn't decode weights that are not stabilized
 
-const char* _XMTZC04HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v1\",\"model_id\":\"XMTZC04HM\",\"condition\":[\"uuid\",\"contain\",\"181d\",\"&\",\"servicedata\",\"index\",0,\"2\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",100]}}}";
+const char* _XMTZC04HM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v1\",\"model_id\":\"XMTZC04HM\",\"condition\":[\"uuid\",\"contain\",\"181d\"],\"properties\":{\"unit\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"static_value\",\"kg\"]},\"weight\":{\"condition\":[\"servicedata\",1,\"2\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",200]},\"_unit\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"static_value\",\"lbs\"]},\"_weight\":{\"condition\":[\"servicedata\",1,\"3\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",2,4,true,false],\"post_proc\":[\"/\",100]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"Miscale_v1",
    "model_id":"XMTZC04HM",
-   "condition":["uuid", "contain", "181d", "&", "servicedata", "index", 0, "2"],
+   "condition":["uuid", "contain", "181d"],
    "properties":{
       "unit":{
          "condition":["servicedata", 1, "2"],


### PR DESCRIPTION
XMTZC04HM decoder with uuid condition only

Unless there were other reasons why an additional condition of **"servicedata", "index", 0,** was added to the MiScale v1 decoder, only using the uuid, similar to the Miscale_v2 decoder, will allow for other XMTZC04HM variants to be recognised.

Related to

https://github.com/1technophile/OpenMQTTGateway/issues/1166

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
