### PR TITLE
Add Microsoft Advertising Beacon (Connected Devices Platform) decoder

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -41,6 +41,7 @@ module.exports = {
             'devices/IBT_6XS',
             'devices/IBT_2X',
             'devices/iNode',
+            'devices/MS_CDP',
             'devices/MokoBeacon',
             'devices/MBXPRO',
             'devices/CGDK2',

--- a/docs/devices/MS_CDP.md
+++ b/docs/devices/MS_CDP.md
@@ -1,0 +1,12 @@
+# Microsoft Advertising Beacon 
+
+|Model Id|[MS-CDP](https://github.com/theengs/decoder/blob/development/src/devices/MS_CDP_json.h)|
+|-|-|
+|Brand|Generic|
+|Model|MS-CDP|
+|Short Description|Microsoft Advertising Beacon (Connected Devices Platform)|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|Dependent on device|
+|Exchanged data|device type|
+|Encrypted|No|

--- a/docs/devices/MS_CDP.md
+++ b/docs/devices/MS_CDP.md
@@ -8,5 +8,5 @@
 |Communication|BLE broadcast|
 |Frequency|2.4Ghz|
 |Power source|Dependent on device|
-|Exchanged data|device type|
+|Exchanged data|device type, salt, device hash|
 |Encrypted|No|

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -82,6 +82,7 @@ public:
     RUUVITAG_RAWV1,
     RUUVITAG_RAWV2,
     BM_V23,
+    MS_CDP,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -40,6 +40,7 @@
 #include "devices/LYWSD03MMC_PVVX_json.h"
 #include "devices/LYWSDCGQ_json.h"
 #include "devices/MBXPRO_json.h"
+#include "devices/MS_CDP_json.h"
 #include "devices/MUE4094RT_json.h"
 #include "devices/Miband_json.h"
 #include "devices/Mokobeacon_json.h"
@@ -92,4 +93,5 @@ const char* _devices[][2] = {
     {_RuuviTag_RAWv1_json, _RuuviTag_RAWv1_json_props},
     {_RuuviTag_RAWv2_json, _RuuviTag_RAWv2_json_props},
     {_BM_V23_json, _BM_V23_json_props},
+    {_MS_CDP_json, _MS_CDP_json_props},
 };

--- a/src/devices/MS_CDP_json.h
+++ b/src/devices/MS_CDP_json.h
@@ -1,0 +1,57 @@
+const char* _MS_CDP_json = "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"condition\":[\"manufacturerdata\",\"index\",0,\"060001\"],\"properties\":{\"device\":{\"condition\":[\"manufacturerdata\",7,\"1\"],\"decoder\":[\"static_value\",\"Xbox One\"]},\"_device\":{\"condition\":[\"manufacturerdata\",7,\"6\"],\"decoder\":[\"static_value\",\"Apple iPhone\"]},\"__device\":{\"condition\":[\"manufacturerdata\",7,\"7\"],\"decoder\":[\"static_value\",\"Apple iPad\"]},\"___device\":{\"condition\":[\"manufacturerdata\",7,\"8\"],\"decoder\":[\"static_value\",\"Android device\"]},\"____device\":{\"condition\":[\"manufacturerdata\",7,\"9\"],\"decoder\":[\"static_value\",\"Windows 10 Desktop\"]},\"_____device\":{\"condition\":[\"manufacturerdata\",7,\"11\"],\"decoder\":[\"static_value\",\"Windows 10 Phone\"]},\"______device\":{\"condition\":[\"manufacturerdata\",7,\"12\"],\"decoder\":[\"static_value\",\"Linux device\"]},\"_______device\":{\"condition\":[\"manufacturerdata\",7,\"17\"],\"decoder\":[\"static_value\",\"Windows IoT\"]},\"________device\":{\"condition\":[\"manufacturerdata\",7,\"14\"],\"decoder\":[\"static_value\",\"Surface Hub\"]}}}";
+/*R""""(
+{
+   "brand":"GENERIC",
+   "model":"MS-CDP",
+   "model_id":"MS-CDP",
+   "condition":["manufacturerdata", "index", 0, "060001"],
+   "properties":{
+      "device":{
+         "condition":["manufacturerdata", 7, "1"],
+         "decoder":["static_value", "Xbox One"]
+      },
+      "_device":{
+         "condition":["manufacturerdata", 7, "6"],
+         "decoder":["static_value", "Apple iPhone"]
+      },
+      "__device":{
+         "condition":["manufacturerdata", 7, "7"],
+         "decoder":["static_value", "Apple iPad"]
+      },
+      "___device":{
+         "condition":["manufacturerdata", 7, "8"],
+         "decoder":["static_value", "Android device"]
+      },
+      "____device":{
+         "condition":["manufacturerdata", 7, "9"],
+         "decoder":["static_value", "Windows 10 Desktop"]
+      },
+      "_____device":{
+         "condition":["manufacturerdata", 7, "11"],
+         "decoder":["static_value", "Windows 10 Phone"]
+      },
+      "______device":{
+         "condition":["manufacturerdata", 7, "12"],
+         "decoder":["static_value", "Linux device"]
+      },
+      "_______device":{
+         "condition":["manufacturerdata", 7, "17"],
+         "decoder":["static_value", "Windows IoT"]
+      },
+      "________device":{
+         "condition":["manufacturerdata", 7, "14"],
+         "decoder":["static_value", "Surface Hub"]
+      }
+   }
+})"""";*/
+
+const char* _MS_CDP_json_props = "{\"properties\":{\"device\":{\"unit\":\"\",\"name\":\"device_type\"}}}";
+/*R""""(
+{
+   "properties":{
+      "device":{
+         "unit":"",
+         "name":"device_type"
+      }
+   }
+})"""";*/

--- a/src/devices/MS_CDP_json.h
+++ b/src/devices/MS_CDP_json.h
@@ -1,4 +1,4 @@
-const char* _MS_CDP_json = "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"condition\":[\"manufacturerdata\",\"index\",0,\"060001\"],\"properties\":{\"device\":{\"condition\":[\"manufacturerdata\",7,\"1\"],\"decoder\":[\"static_value\",\"Xbox One\"]},\"_device\":{\"condition\":[\"manufacturerdata\",7,\"6\"],\"decoder\":[\"static_value\",\"Apple iPhone\"]},\"__device\":{\"condition\":[\"manufacturerdata\",7,\"7\"],\"decoder\":[\"static_value\",\"Apple iPad\"]},\"___device\":{\"condition\":[\"manufacturerdata\",7,\"8\"],\"decoder\":[\"static_value\",\"Android device\"]},\"____device\":{\"condition\":[\"manufacturerdata\",7,\"9\"],\"decoder\":[\"static_value\",\"Windows 10 Desktop\"]},\"_____device\":{\"condition\":[\"manufacturerdata\",7,\"11\"],\"decoder\":[\"static_value\",\"Windows 10 Phone\"]},\"______device\":{\"condition\":[\"manufacturerdata\",7,\"12\"],\"decoder\":[\"static_value\",\"Linux device\"]},\"_______device\":{\"condition\":[\"manufacturerdata\",7,\"17\"],\"decoder\":[\"static_value\",\"Windows IoT\"]},\"________device\":{\"condition\":[\"manufacturerdata\",7,\"14\"],\"decoder\":[\"static_value\",\"Surface Hub\"]}}}";
+const char* _MS_CDP_json = "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"condition\":[\"manufacturerdata\",\"index\",0,\"060001\"],\"properties\":{\"device\":{\"condition\":[\"manufacturerdata\",7,\"1\"],\"decoder\":[\"static_value\",\"Xbox One\"]},\"_device\":{\"condition\":[\"manufacturerdata\",7,\"6\"],\"decoder\":[\"static_value\",\"Apple iPhone\"]},\"__device\":{\"condition\":[\"manufacturerdata\",7,\"7\"],\"decoder\":[\"static_value\",\"Apple iPad\"]},\"___device\":{\"condition\":[\"manufacturerdata\",7,\"8\"],\"decoder\":[\"static_value\",\"Android device\"]},\"____device\":{\"condition\":[\"manufacturerdata\",7,\"9\"],\"decoder\":[\"static_value\",\"Windows 10 Desktop\"]},\"_____device\":{\"condition\":[\"manufacturerdata\",7,\"11\"],\"decoder\":[\"static_value\",\"Windows 10 Phone\"]},\"______device\":{\"condition\":[\"manufacturerdata\",7,\"12\"],\"decoder\":[\"static_value\",\"Linux device\"]},\"_______device\":{\"condition\":[\"manufacturerdata\",7,\"17\"],\"decoder\":[\"static_value\",\"Windows IoT\"]},\"________device\":{\"condition\":[\"manufacturerdata\",7,\"14\"],\"decoder\":[\"static_value\",\"Surface Hub\"]},\"salt\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",12,8]},\"hash\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",20,32]}}}}";
 /*R""""(
 {
    "brand":"GENERIC",
@@ -35,23 +35,38 @@ const char* _MS_CDP_json = "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_
          "decoder":["static_value", "Linux device"]
       },
       "_______device":{
-         "condition":["manufacturerdata", 7, "17"],
+         "condition":["manufacturerdata", 7, "13"],
          "decoder":["static_value", "Windows IoT"]
       },
       "________device":{
          "condition":["manufacturerdata", 7, "14"],
          "decoder":["static_value", "Surface Hub"]
+      },
+      "salt":{
+         "decoder":["string_from_hex_data", "manufacturerdata", 12, 8]
+      },
+      "hash":{
+         "decoder":["string_from_hex_data", "manufacturerdata", 20, 32]
       }
    }
 })"""";*/
 
-const char* _MS_CDP_json_props = "{\"properties\":{\"device\":{\"unit\":\"\",\"name\":\"device_type\"}}}";
+const char* _MS_CDP_json_props = "{\"properties\":{\"device\":{\"unit\":\"string\",\"name\":\"device type\"},\"salt\":{\"unit\":\"hex\",\"name\":\"salt\"},\"hash\":{\"unit\":\"hex\",\"name\":\"device hash\"}}}";
 /*R""""(
 {
    "properties":{
       "device":{
-         "unit":"",
-         "name":"device_type"
+         "unit":"string",
+         "name":"device type"
+      },
+      "salt":{
+         "unit":"hex",
+         "name":"salt"
+      },
+      "hash":{
+         "unit":"hex",
+         "name":"device hash"
       }
+
    }
 })"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -63,7 +63,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":163.835,\"tempf\":326.903,\"hum\":163.8350,\"pres\":1155.34,\"accx\":32.767,\"accy\":32.767,\"accz\":32.767,\"volt\":3.646,\"tx\":20,\"mov\":254,\"seq\":65534}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":-163.835,\"tempf\":-262.903,\"hum\":0,\"pres\":500,\"accx\":-32.767,\"accy\":-32.767,\"accz\":-32.767,\"volt\":1.6,\"tx\":-40,\"mov\":0,\"seq\":0}",
     "{\"brand\":\"BlueMaestro\",\"model\":\"TempoDisc\",\"model_id\":\"BM_V23\",\"tempc\":23.9,\"tempf\":75.02,\"dp\":10.8,\"hum\":43.5,\"volt\":2.56}",
-    "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"device\":\"Windows 10 Desktop\"}",
+    "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"device\":\"Windows 10 Desktop\",\"salt\":\"ac6d90ec\",\"hash\":\"0132b3204cd39c7ced3e48436ba15dc6\"}",
 };
 
 const char* expected_uuid[] = {
@@ -170,7 +170,7 @@ const char* test_mfgdata[][3] = {
     {"RuuviTag RAWv2", "RuuviTag maximum values", "9904057FFFFFFEFFFE7FFF7FFF7FFFFFDEFEFFFECBB8334C884F"},
     {"RuuviTag RAWv2", "RuuviTag minimum values", "9904058001000000008001800180010000000000CBB8334C884F"},
     {"BM_V23", "V23", "330117560e10177000ef01b3006c0100"},
-    {"MS-CDP", "Windows 10 Desktop", "060001092002bba2836fd04e543bcd883eae1ab037dab37a237c4b6864"},
+    {"MS-CDP", "Windows 10 Desktop", "060001092002ac6d90ec0132b3204cd39c7ced3e48436ba15dc6314778"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -63,6 +63,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":163.835,\"tempf\":326.903,\"hum\":163.8350,\"pres\":1155.34,\"accx\":32.767,\"accy\":32.767,\"accz\":32.767,\"volt\":3.646,\"tx\":20,\"mov\":254,\"seq\":65534}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":-163.835,\"tempf\":-262.903,\"hum\":0,\"pres\":500,\"accx\":-32.767,\"accy\":-32.767,\"accz\":-32.767,\"volt\":1.6,\"tx\":-40,\"mov\":0,\"seq\":0}",
     "{\"brand\":\"BlueMaestro\",\"model\":\"TempoDisc\",\"model_id\":\"BM_V23\",\"tempc\":23.9,\"tempf\":75.02,\"dp\":10.8,\"hum\":43.5,\"volt\":2.56}",
+    "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"device\":\"Windows 10 Desktop\"}",
 };
 
 const char* expected_uuid[] = {
@@ -169,6 +170,7 @@ const char* test_mfgdata[][3] = {
     {"RuuviTag RAWv2", "RuuviTag maximum values", "9904057FFFFFFEFFFE7FFF7FFF7FFFFFDEFEFFFECBB8334C884F"},
     {"RuuviTag RAWv2", "RuuviTag minimum values", "9904058001000000008001800180010000000000CBB8334C884F"},
     {"BM_V23", "V23", "330117560e10177000ef01b3006c0100"},
+    {"MS-CDP", "Windows 10 Desktop", "060001092002bba2836fd04e543bcd883eae1ab037dab37a237c4b6864"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
@@ -195,6 +197,7 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
   TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2,
   TheengsDecoder::BLE_ID_NUM::RUUVITAG_RAWV2,
   TheengsDecoder::BLE_ID_NUM::BM_V23,
+  TheengsDecoder::BLE_ID_NUM::MS_CDP,
 };
 
 // uuid test input [test name] [uuid] [data source] [data]


### PR DESCRIPTION
## Description:

This adds a decoder for [Microsoft Advertising Beacons](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cdp/77b446d0-8cea-4821-ad21-fabdf4d9a569), which are BLE packets with manufacturer-specific data following the [Connected Devices Platform](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cdp/f5a15c56-ac3a-48f9-8c51-07b2eadbe9b4) protocol.

This decodes the device type, salt and device hash.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
