### PR TITLE
Add Google/Apple Exposure Notification (GAEN) decoder

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -32,6 +32,7 @@ module.exports = {
             'devices/BM_V23',
             'devices/CGD1',
             'devices/CGP1W',
+            'devices/GAEN',
             'devices/H5072',
             'devices/H5075',
             'devices/H5102',

--- a/docs/devices/GAEN.md
+++ b/docs/devices/GAEN.md
@@ -1,0 +1,12 @@
+# Google/Apple Exposure Notification
+
+|Model Id|[MS-CDP](https://github.com/theengs/decoder/blob/development/src/devices/GAEN_json.h)|
+|-|-|
+|Brand|Generic|
+|Model|GAEN|
+|Short Description|Google/Apple Exposure Notification (GAEN) for digital contact tracing|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|Dependent on device|
+|Exchanged data|rolling proximity identifier, associated encrypted metadata|
+|Encrypted|Yes|

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -83,6 +83,7 @@ public:
     RUUVITAG_RAWV2,
     BM_V23,
     MS_CDP,
+    GAEN,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -25,6 +25,7 @@
 #include "devices/CGH1_json.h"
 #include "devices/CGP1W_json.h"
 #include "devices/CGPR1_json.h"
+#include "devices/GAEN_json.h"
 #include "devices/H5072_json.h"
 #include "devices/H5075_json.h"
 #include "devices/H5102_json.h"
@@ -94,4 +95,5 @@ const char* _devices[][2] = {
     {_RuuviTag_RAWv2_json, _RuuviTag_RAWv2_json_props},
     {_BM_V23_json, _BM_V23_json_props},
     {_MS_CDP_json, _MS_CDP_json_props},
+    {_GAEN_json, _GAEN_json_props},
 };

--- a/src/devices/GAEN_json.h
+++ b/src/devices/GAEN_json.h
@@ -1,0 +1,32 @@
+const char* _GAEN_json = "{\"brand\":\"GENERIC\",\"model\":\"GAEN\",\"model_id\":\"GAEN\",\"condition\":[\"uuid\",\"index\",0,\"fd6f\"],\"properties\":{\"rpi\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",0,32]},\"aem\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",32,8]}}}";
+
+/*R""""(
+{
+   "brand":"GENERIC",
+   "model":"GAEN",
+   "model_id":"GAEN",
+   "condition":["uuid", "index", 0, "fd6f"],
+   "properties":{
+      "rpi":{
+         "decoder":["string_from_hex_data", "servicedata", 0, 32]
+      },
+      "aem":{
+         "decoder":["string_from_hex_data", "servicedata", 32, 8]
+      }
+   }
+})"""";*/
+
+const char* _GAEN_json_props = "{\"properties\":{\"rpi\":{\"unit\":\"hex\",\"name\":\"rolling proximity identifier\"},\"aem\":{\"unit\":\"hex\",\"name\":\"associated encrypted metadata\"}}}";
+/*R""""(
+{
+   "properties":{
+      "rpi":{
+         "unit":"hex",
+         "name":"rolling proximity identifier"
+      },
+      "aem":{
+         "unit":"hex",
+         "name":"associated encrypted metadata"
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -72,6 +72,7 @@ const char* expected_uuid[] = {
     "{\"brand\":\"Xiaomi\",\"model\":\"Miscale_v2\",\"model_id\":\"XMTZC05HM\",\"unit\":\"kg\",\"weight\":72.45,\"impedance\":503}",
     "{\"brand\":\"Mokosmart\",\"model\":\"Beacon\",\"model_id\":\"Mokobeacon\",\"batt\":100,\"x_axis\":-24576,\"y_axis\":-3841,\"z_axis\":-8189}",
     "{\"brand\":\"Mokosmart\",\"model\":\"BeaconX Pro\",\"model_id\":\"MBXPRO\",\"tempc\":27.4,\"tempf\":81.32,\"hum\":49.4,\"volt\":3.247}",
+    "{\"brand\":\"GENERIC\",\"model\":\"GAEN\",\"model_id\":\"GAEN\",\"rpi\":\"e7c6d34c71e48baf278bd99be74685bc\",\"aem\":\"a78126ab\"}",
 };
 
 // Service data test input [test name] [data]
@@ -207,6 +208,7 @@ const char* test_uuid[][4] = {
     {"Miscale_v2", "0x181b", "servicedata", "0284e5070c170c301df7019a38"},
     {"Mokobeacon", "0xff01", "servicedata", "64000000005085a000f0ffe003"},
     {"MokoXPro", "feab", "servicedata", "70000a011201ee0caf03def14635998a"},
+    {"GAEN", "fd6f", "servicedata", "e7c6d34c71e48baf278bd99be74685bca78126ab"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
@@ -215,6 +217,7 @@ TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
   TheengsDecoder::BLE_ID_NUM::XMTZC05HM,
   TheengsDecoder::BLE_ID_NUM::MOKOBEACON,
   TheengsDecoder::BLE_ID_NUM::MOKOBEACONXPRO,
+  TheengsDecoder::BLE_ID_NUM::GAEN,
 };
 
 template <typename T>


### PR DESCRIPTION
## Description:

This adds a decoder for [Google/Apple Exposure Notification (GAEN)](https://blog.google/documents/70/Exposure_Notification_-_Bluetooth_Specification_v1.2.2.pdf) packets, sent by digital contact tracing apps on mobile phones.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
