### PR TITLE
static_value bool implementation

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -441,6 +441,9 @@ int TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
             success = i_main;
             DEBUG_PRINT("found value = %s : %.2f\n", _key.c_str(), jsondata[_key].as<double>());
           } else if (strstr((const char*)decoder[0], "static_value") != nullptr) {
+            if (prop.containsKey("is_bool") && !decoder[1].is<std::string>()) {
+              decoder[1] = (bool)decoder[1] ;
+            }
             jsondata[sanitizeJsonKey(kv.key().c_str())] = decoder[1];
             success = i_main;
           } else if (strstr((const char*)decoder[0], "string_from_hex_data") != nullptr) {

--- a/src/devices/MUE4094RT_json.h
+++ b/src/devices/MUE4094RT_json.h
@@ -1,4 +1,4 @@
-const char* _MUE4094RT_json = "{\"brand\":\"Xiaomi\",\"model\":\"MiLamp\",\"model_id\":\"MUE4094RT\",\"condition\":[\"servicedata\",\"contain\",\"4030dd\"],\"properties\":{\"pres\":{\"condition\":[\"servicedata\",0,\"4812\"],\"decoder\":[\"static_value\",\"true\"],\"is_bool\":1},\"darkness\":{\"condition\":[\"servicedata\",0,\"4812\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,true]}}}";
+const char* _MUE4094RT_json = "{\"brand\":\"Xiaomi\",\"model\":\"MiLamp\",\"model_id\":\"MUE4094RT\",\"condition\":[\"servicedata\",\"contain\",\"4030dd\"],\"properties\":{\"pres\":{\"condition\":[\"servicedata\",0,\"4812\"],\"decoder\":[\"static_value\",true],\"is_bool\":1},\"darkness\":{\"condition\":[\"servicedata\",0,\"4812\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,true]}}}";
 /*
 R""""(
 {
@@ -9,7 +9,7 @@ R""""(
    "properties":{
       "pres":{
          "condition":["servicedata", 0, "4812"],
-         "decoder":["static_value","true"],
+         "decoder":["static_value", true],
          "is_bool":1
       },
       "darkness":{


### PR DESCRIPTION
static_value bool implementation and MUE4094RT decoder adjustment

as per discussion 

https://github.com/theengs/decoder/discussions/90

and testing with various variations, a static_value property value was always published as a string. This now makes static_value bool results possible, only if the static_value definition is  NOT definded as a string, i.e.

```
      "pres":{
         "decoder":["static_value", true],
         "is_bool":1
      },

      "pres":{
         "decoder":["static_value", false],
         "is_bool":1
      },
```

now resulting in

`"pres":true … "pres":false`

Amended the MUE4094RT as well, but couldn't really create proper test cases, as I don't have realistic servicedata samples, but working as expected in the SwitchBot Curtain change

https://github.com/DigiH/decoder/commit/7090b79d87dbe462f0243c5d127428c16c271cbb

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
