### PR TITLE
Initial NOT implementation

### DIFF
--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -82,6 +82,22 @@ Here we have a single property that defines a value that we want to decode. The 
 The second parameter is the index of the data source to look for the value. The third parameter is the value to test for.
 If the condition is met the data will be decoded and added to the JsonObject.
 
+Property conditions also allow for a NOT comparison, as in
+```
+ "properties":{
+      "tempc":{
+         "condition":["manufacturerdata", 24, "!", "ffff"],
+         "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true, false],
+         "post_proc":["/", 10]
+      },
+```
+
+where then the fourth parameter is the value to test for.
+
+::: warning Note
+The NOT comparison is case sensitive! Therefor any NOT comparisons should be defined in lower case, as this is the format in which devices' "servicedata" and "manufacturerdata" are being reported.
+:::
+
 `decoder` is a JSON array that specifies the decoder function and parameters to decode the value.
 The first parameter is the name of the function to call, The available functions are:
 - "value_from_hex_data"  - converts the hex string value into an `integer` or `double` type.

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -300,14 +300,27 @@ int TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
         bool cond_met = prop_condition.isNull();
 
         for (int i = 0; i < cond_size; i += 4) {
-          if (svc_data &&
-              strstr((const char*)prop_condition[i], "servicedata") != nullptr &&
-              svc_data[prop_condition[i + 1].as<int>()] == *prop_condition[i + 2].as<const char*>()) {
-            cond_met = true;
-          } else if (mfg_data &&
-                     strstr((const char*)prop_condition[i], "manufacturerdata") != nullptr &&
-                     mfg_data[prop_condition[i + 1].as<int>()] == *prop_condition[i + 2].as<const char*>()) {
-            cond_met = true;
+          if (strstr((const char*)prop_condition[i + 2], "!") != nullptr) {
+            if (svc_data &&
+                strstr((const char*)prop_condition[i], "servicedata") != nullptr &&
+                svc_data[prop_condition[i + 1].as<int>()] != *prop_condition[i + 3].as<const char*>()) {
+              cond_met = true;
+            } else if (mfg_data &&
+                      strstr((const char*)prop_condition[i], "manufacturerdata") != nullptr &&
+                      mfg_data[prop_condition[i + 1].as<int>()] != *prop_condition[i + 3].as<const char*>()) {
+              cond_met = true;
+            }
+            i++;
+          } else {
+            if (svc_data &&
+                strstr((const char*)prop_condition[i], "servicedata") != nullptr &&
+                svc_data[prop_condition[i + 1].as<int>()] == *prop_condition[i + 2].as<const char*>()) {
+              cond_met = true;
+            } else if (mfg_data &&
+                      strstr((const char*)prop_condition[i], "manufacturerdata") != nullptr &&
+                      mfg_data[prop_condition[i + 1].as<int>()] == *prop_condition[i + 2].as<const char*>()) {
+              cond_met = true;
+            }
           }
 
           if (!cond_met && cond_size > (i + 3) && *prop_condition[i + 3].as<const char*>() == '|') {

--- a/src/devices/IBT_2X_json.h
+++ b/src/devices/IBT_2X_json.h
@@ -7,20 +7,22 @@ const char* _IBT_2X_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id
    "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", ">=", 24, "index", 0, "0000","&","manufacturerdata", "<=", 28, "index", 0, "0000"],
    "properties":{
       "tempc":{
-         "condition":["manufacturerdata", 0, "00000000"],
+         "condition":["manufacturerdata", 0, "00000000", "&", "manufacturerdata", 16, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 16, 4, true, false],
          "post_proc":["/", 10]
       },
       "_tempc":{
+         "condition":["manufacturerdata", 20, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc2":{
-         "condition":["manufacturerdata", 0, "00000000"],
+         "condition":["manufacturerdata", 0, "00000000", "&", "manufacturerdata", 20, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],
          "post_proc":["/", 10]
       },
       "_tempc2":{
+         "condition":["manufacturerdata", 24, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true, false],
          "post_proc":["/", 10]
       }

--- a/src/devices/IBT_4XS_json.h
+++ b/src/devices/IBT_4XS_json.h
@@ -8,18 +8,22 @@ const char* _IBT_4XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_i
    "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", "=" ,36 ,"index", 0, "00000000"],
    "properties":{
       "tempc":{
+         "condition":["manufacturerdata", 20, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc2":{
+         "condition":["manufacturerdata", 24, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc3":{
+         "condition":["manufacturerdata", 28, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 28, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc4":{
+         "condition":["manufacturerdata", 32, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 32, 4, true, false],
          "post_proc":["/", 10]
       }

--- a/src/devices/IBT_6XS_json.h
+++ b/src/devices/IBT_6XS_json.h
@@ -1,4 +1,4 @@
-const char* _IBT_6XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-6XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",40,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_6XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-6XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",40,\"index\",0,\"0000\"],\"properties\":{\"tempc\":{\"condition\":[\"manufacturerdata\",16,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",16,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"condition\":[\"manufacturerdata\",20,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"condition\":[\"manufacturerdata\",24,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"condition\":[\"manufacturerdata\",28,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"condition\":[\"manufacturerdata\",32,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"condition\":[\"manufacturerdata\",36,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,4,true,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
@@ -8,26 +8,32 @@ const char* _IBT_6XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_i
    "condition":["name", "index", 0, "iBBQ","&","manufacturerdata","=", 40, "index", 0, "0000"],
    "properties":{
       "tempc":{
+         "condition":["manufacturerdata", 16, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 16, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc2":{
+         "condition":["manufacturerdata", 20, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc3":{
+         "condition":["manufacturerdata", 24, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc4":{
+         "condition":["manufacturerdata", 28, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 28, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc5":{
+         "condition":["manufacturerdata", 32, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 32, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc6":{
+         "condition":["manufacturerdata", 36, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 36, 4, true, false],
          "post_proc":["/", 10]
       }

--- a/src/devices/Miband_json.h
+++ b/src/devices/Miband_json.h
@@ -1,4 +1,4 @@
-const char* _Miband_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miband\",\"model_id\":\"MiBand\",\"condition\":[\"uuid\",\"contain\",\"fee0\"],\"properties\":{\"steps\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",0,4,true,false]},\"act_bpm\":{\"condition\":[\"manufacturerdata\",10,\"3\",\"|\",\"manufacturerdata\",10,\"4\",\"|\",\"manufacturerdata\",10,\"5\",\"|\",\"manufacturerdata\",10,\"6\",\"|\",\"manufacturerdata\",10,\"7\",\"|\",\"manufacturerdata\",10,\"8\",\"|\",\"manufacturerdata\",10,\"9\",\"|\",\"manufacturerdata\",10,\"a\",\"|\",\"manufacturerdata\",10,\"b\",\"|\",\"manufacturerdata\",10,\"c\",\"|\",\"manufacturerdata\",10,\"d\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,false]}}}";
+const char* _Miband_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miband\",\"model_id\":\"MiBand\",\"condition\":[\"uuid\",\"contain\",\"fee0\"],\"properties\":{\"steps\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",0,4,true,false]},\"act_bpm\":{\"condition\":[\"manufacturerdata\",10,\"!\",\"f\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,false]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
@@ -10,7 +10,7 @@ const char* _Miband_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miband\",\"model_i
          "decoder":["value_from_hex_data", "servicedata", 0, 4, true, false]
       },
       "act_bpm":{
-         "condition":["manufacturerdata", 10, "3", "|", "manufacturerdata", 10, "4", "|", "manufacturerdata", 10, "5", "|", "manufacturerdata", 10, "6", "|", "manufacturerdata", 10, "7", "|", "manufacturerdata", 10, "8", "|", "manufacturerdata", 10, "9", "|", "manufacturerdata", 10, "a", "|", "manufacturerdata", 10, "b", "|", "manufacturerdata", 10, "c", "|", "manufacturerdata", 10, "d"],
+         "condition":["manufacturerdata", 10, "!", "f"],
          "decoder":["value_from_hex_data", "manufacturerdata", 10, 2, false, false]
       }
    }

--- a/src/devices/SOLIS_6_json.h
+++ b/src/devices/SOLIS_6_json.h
@@ -1,4 +1,4 @@
-const char* _SOLIS_6_json = "{\"brand\":\"Tenergy\",\"model\":\"SOLIS 6 probes\",\"model_id\":\"SOLIS_6\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",44,\"index\",0,\"000000000\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _SOLIS_6_json = "{\"brand\":\"Tenergy\",\"model\":\"SOLIS 6 Probes\",\"model_id\":\"SOLIS_6\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",44,\"index\",0,\"000000000\"],\"properties\":{\"tempc\":{\"condition\":[\"manufacturerdata\",20,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"condition\":[\"manufacturerdata\",24,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"condition\":[\"manufacturerdata\",28,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"condition\":[\"manufacturerdata\",32,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"condition\":[\"manufacturerdata\",36,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"condition\":[\"manufacturerdata\",40,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,true,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
@@ -8,26 +8,32 @@ const char* _SOLIS_6_json = "{\"brand\":\"Tenergy\",\"model\":\"SOLIS 6 probes\"
    "condition":["name", "index", 0, "iBBQ","&","manufacturerdata","=", 44, "index", 0, "000000000"],
    "properties":{
       "tempc":{
+         "condition":["manufacturerdata", 20, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc2":{
+         "condition":["manufacturerdata", 24, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc3":{
+         "condition":["manufacturerdata", 28, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 28, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc4":{
+         "condition":["manufacturerdata", 32, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 32, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc5":{
+         "condition":["manufacturerdata", 36, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 36, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc6":{
+         "condition":["manufacturerdata", 40, "!", "f6ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 40, 4, true, false],
          "post_proc":["/", 10]
       }

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -57,7 +57,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"iNode\",\"model\":\"Energy Meter\",\"model_id\":\"INEM\",\"power\":5304,\"energy\":18.8804,\"batt\":80}",
     "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-2X\",\"tempc\":23,\"tempf\":73.4,\"tempc2\":23,\"tempf2\":73.4}",
     "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-2X\",\"tempc\":22,\"tempf\":71.6,\"tempc2\":21,\"tempf2\":69.8}",
-    "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-6XS\",\"tempc\":21,\"tempf\":69.8,\"tempc2\":20,\"tempf2\":68,\"tempc3\":6552.6,\"tempf3\":11826.68,\"tempc4\":21,\"tempf4\":69.8,\"tempc5\":6552.6,\"tempf5\":11826.68,\"tempc6\":6552.6,\"tempf6\":11826.68}",
+    "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-6XS\",\"tempc\":21,\"tempf\":69.8,\"tempc2\":20,\"tempf2\":68,\"tempc4\":21,\"tempf4\":69.8}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv1\",\"hum\":20.5,\"tempc\":26.3,\"tempf\":79.34,\"pres\":1027.66,\"accx\":-1,\"accy\":-1.726,\"accz\":0.714,\"volt\":2.899}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv1\",\"hum\":127.5,\"tempc\":127.99,\"tempf\":262.382,\"pres\":1155.35,\"accx\":32.767,\"accy\":32.767,\"accz\":32.767,\"volt\":65.535}",
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv1\",\"hum\":0,\"tempc\":-127.99,\"tempf\":-198.382,\"pres\":500,\"accx\":-32.767,\"accy\":-32.767,\"accz\":-32.767,\"volt\":0}",
@@ -66,7 +66,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",\"model_id\":\"RuuviTag_RAWv2\",\"tempc\":-163.835,\"tempf\":-262.903,\"hum\":0,\"pres\":500,\"accx\":-32.767,\"accy\":-32.767,\"accz\":-32.767,\"volt\":1.6,\"tx\":-40,\"mov\":0,\"seq\":0}",
     "{\"brand\":\"BlueMaestro\",\"model\":\"TempoDisc\",\"model_id\":\"BM_V23\",\"tempc\":23.9,\"tempf\":75.02,\"dp\":10.8,\"hum\":43.5,\"volt\":2.56}",
     "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"device\":\"Windows 10 Desktop\",\"salt\":\"ac6d90ec\",\"hash\":\"0132b3204cd39c7ced3e48436ba15dc6\"}",
-    "{\"brand\":\"Tenergy\",\"model\":\"SOLIS 6 probes\",\"model_id\":\"SOLIS_6\",\"tempc\":20,\"tempf\":68,\"tempc2\":20,\"tempf2\":68,\"tempc3\":6552.6,\"tempf3\":11826.68,\"tempc4\":6552.6,\"tempf4\":11826.68,\"tempc5\":6552.6,\"tempf5\":11826.68,\"tempc6\":6552.6,\"tempf6\":11826.68}",
+    "{\"brand\":\"Tenergy\",\"model\":\"SOLIS 6 Probes\",\"model_id\":\"SOLIS_6\",\"tempc\":20,\"tempf\":68,\"tempc2\":20,\"tempf2\":68}",
 
 };
 
@@ -193,9 +193,9 @@ const char* test_mfgdata[][3] = {
     {"Inkbird TH2", "tps", "76fb03150110805908"},
     {"iNode", "test1", "90826300f0cf0000c409a20080"},
     {"iNode", "test2", "9082dd0061b80000c409a00080"},
-    {"IBT-2X", "iBBQ", "0000FC45C30C458EE600E600"},
+    {"IBT-2X", "iBBQ", "0000fc45c30c458ee600e600"},
     {"IBT-2X", "iBBQ", "00000000fc45c30d38a8dc00d200"},
-    {"IBT-6XS", "iBBQ", "00003403DE2745CDD200C800F6FFD200F6FFF6FF"},
+    {"IBT-6XS", "iBBQ", "00003403de2745cdd200c800f6ffd200f6fff6ff"},
     {"RuuviTag RAWv1", "RuuviTag", "990403291A1ECE1EFC18F94202CA0B53"},
     {"RuuviTag RAWv1", "RuuviTag maximum values", "990403FF7F63FFFF7FFF7FFF7FFFFFFF"},
     {"RuuviTag RAWv1", "RuuviTag minimum values", "99040300FF6300008001800180010000"},


### PR DESCRIPTION
This ist just as much a test for myself to delve deeper into the decoder code, as the implementation of the previously discussed NOT condition testing. Maybe not implemented as elegantly as could be, so any comments on this are welcome ;)

This allows for some previous long stringed OR conditions to be greatly reduced, as in the MiBand act_bpm property for example, and also allows for some unrealistic temperatures not to be published when the probes are not connected as in the Inkbird 6XS BBQ and Tenergy SOLIS 6 BBQ cases - amended the test cases accordingly. I assume the Inkbird 2X BBQ and Inkbird 4XS BBQ would benefit from the same implementation, but didn't want to change the decoders, as the current test cases don't confirm this assumption.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
