### PR TITLE
Add nesting and NOT condition support for device conditions.

### DIFF
--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -67,7 +67,7 @@ This will match if the service data at index 0 is "0804" `OR` "8804".
 This will result in a positive detection if the service data at index `0` == `0x1234` and the service data at index `5` == `0x5678`, otherwise, if the service data at index `30` == `0xABCD`, the result will also be positive.
 
 ::: warning Note
-Nesting is discouraged from use wherever possible as the recursive nature may cause stack overflowing in some circumstaces.  
+Nesting is discouraged from use wherever possible as the recursive nature may cause stack overflowing in some circumstances.  
 The above example could be re-written as:  
 `"condition": ["servicedata", "index", 30, "ABCD", "|", "servicedata", "index", 0, "1234", "&" "servicedata", "index", 5, "5678"]`  
 Which has the same result, without nesting.
@@ -102,7 +102,7 @@ If the condition is met the data will be decoded and added to the JsonObject.
 This will result in a positive detection if the service data at index `25` == `4` and the service data at index `26` == `5`, otherwise, if the service data at index `30` == `0xABCD`, the result will also be positive.
 
 ::: warning Note
-Nesting is discouraged from use wherever possible as the recursive nature may cause stack overflowing in some circumstaces.  
+Nesting is discouraged from use wherever possible as the recursive nature may cause stack overflowing in some circumstances.  
 The above example could be re-written as:  
 `"condition": ["servicedata", 30, "ABCD", "|", "servicedata", 25, "4", "&" "servicedata", 5, "5"]`  
 Which has the same result, without nesting.

--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -62,6 +62,21 @@ The third parameter (fifth if data length is specified) can be either the index 
 For example: `"condition":["servicedata", "index", 0, "0804", '|', "servicedata", "index", 0, "8804"]`  
 This will match if the service data at index 0 is "0804" `OR` "8804".
 
+`condition` can contain JSON arrays that can be processed separately. This allows for nesting of detection tests such as:  
+`"condition": [["servicedata", "index", 0, "1234", "&" "servicedata", "index", 5, "5678"], "|", "servicedata", "index", 30, "ABCD"]`  
+This will result in a positive detection if the service data at index `0` == `0x1234` and the service data at index `5` == `0x5678`, otherwise, if the service data at index `30` == `0xABCD`, the result will also be positive.
+
+::: warning Note
+Nesting is discouraged from use wherever possible as the recursive nature may cause stack overflowing in some circumstaces.  
+The above example could be re-written as:  
+`"condition": ["servicedata", "index", 30, "ABCD", "|", "servicedata", "index", 0, "1234", "&" "servicedata", "index", 5, "5678"]`  
+Which has the same result, without nesting.
+:::
+
+`condition` NOT(!) testing; Anytime a condition test value is preceded by a "!", the inverse of the result will be used to determine the result.  
+Example: `"condition": ["servicedata", "index", 30, "!", "ABCD", "&", "servicedata", "index", 0, "1234"]  
+If the value of the service data at index 30 is not 0xABCD and the data at index 0 is 0x1234, the result is a positive detection.
+
 ### Properties
 Properties is a nested JSON object containing one or more JSON objects. In the example above it looks like:
 ```
@@ -81,6 +96,17 @@ Here we have a single property that defines a value that we want to decode. The 
 
 The second parameter is the index of the data source to look for the value. The third parameter is the value to test for.
 If the condition is met the data will be decoded and added to the JsonObject.
+
+`condition` can contain JSON arrays that can be processed separately. This allows for nesting of detection tests such as:  
+`"condition": [["servicedata", 25, "4", "&" "servicedata", 26, "5"], "|", "servicedata", 30, "ABCD"]`  
+This will result in a positive detection if the service data at index `25` == `4` and the service data at index `26` == `5`, otherwise, if the service data at index `30` == `0xABCD`, the result will also be positive.
+
+::: warning Note
+Nesting is discouraged from use wherever possible as the recursive nature may cause stack overflowing in some circumstaces.  
+The above example could be re-written as:  
+`"condition": ["servicedata", 30, "ABCD", "|", "servicedata", 25, "4", "&" "servicedata", 5, "5"]`  
+Which has the same result, without nesting.
+:::
 
 Property conditions also allow for a NOT comparison, as in
 ```

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -94,8 +94,10 @@ private:
   double      value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true);
   double      bf_value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true);
   bool        data_index_is_valid(const char* str, size_t index, size_t len);
-  int         data_length_is_valid(size_t data_len, size_t default_min, JsonArray& condition, int idx);
+  int         data_length_is_valid(size_t data_len, size_t default_min, const JsonArray& condition, int idx);
   bool        checkPropCondition(const JsonArray& prop, const char* svc_data, const char* mfg_data);
+  bool        checkDeviceMatch(const JsonArray& condition, const char* svc_data, const char* mfg_data,
+                               const char* dev_name, const char* svc_uuid);
   std::string sanitizeJsonKey(const char* key_in);
 
   size_t m_docMax = 7168;


### PR DESCRIPTION
## Description:
* New private method added `checkDeviceMatch`
* Conditions for device detection can now use nested JSON arrays to allow more specific evaluation.
* Device conditions can now support a NOT operation when the condition check type "index" and a "!" is preceded before the value to test for.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
