### PR TITLE
Docs example lower casing

### DIFF
--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -63,19 +63,19 @@ For example: `"condition":["servicedata", "index", 0, "0804", '|', "servicedata"
 This will match if the service data at index 0 is "0804" `OR` "8804".
 
 `condition` can contain JSON arrays that can be processed separately. This allows for nesting of detection tests such as:  
-`"condition": [["servicedata", "index", 0, "1234", "&" "servicedata", "index", 5, "5678"], "|", "servicedata", "index", 30, "ABCD"]`  
-This will result in a positive detection if the service data at index `0` == `0x1234` and the service data at index `5` == `0x5678`, otherwise, if the service data at index `30` == `0xABCD`, the result will also be positive.
+`"condition": [["servicedata", "index", 0, "1234", "&" "servicedata", "index", 5, "5678"], "|", "servicedata", "index", 30, "abcd"]`  
+This will result in a positive detection if the service data at index `0` == `0x1234` and the service data at index `5` == `0x5678`, otherwise, if the service data at index `30` == `0xabcd`, the result will also be positive.
 
 ::: warning Note
 Nesting is discouraged from use wherever possible as the recursive nature may cause stack overflowing in some circumstances.  
 The above example could be re-written as:  
-`"condition": ["servicedata", "index", 30, "ABCD", "|", "servicedata", "index", 0, "1234", "&" "servicedata", "index", 5, "5678"]`  
+`"condition": ["servicedata", "index", 30, "abcd", "|", "servicedata", "index", 0, "1234", "&" "servicedata", "index", 5, "5678"]`  
 Which has the same result, without nesting.
 :::
 
 `condition` NOT(!) testing; Anytime a condition test value is preceded by a "!", the inverse of the result will be used to determine the result.  
-Example: `"condition": ["servicedata", "index", 30, "!", "ABCD", "&", "servicedata", "index", 0, "1234"]  
-If the value of the service data at index 30 is not 0xABCD and the data at index 0 is 0x1234, the result is a positive detection.
+Example: `"condition": ["servicedata", "index", 30, "!", "abcd", "&", "servicedata", "index", 0, "1234"]  
+If the value of the service data at index 30 is not 0xabcd and the data at index 0 is 0x1234, the result is a positive detection.
 
 ### Properties
 Properties is a nested JSON object containing one or more JSON objects. In the example above it looks like:
@@ -98,13 +98,13 @@ The second parameter is the index of the data source to look for the value. The 
 If the condition is met the data will be decoded and added to the JsonObject.
 
 `condition` can contain JSON arrays that can be processed separately. This allows for nesting of detection tests such as:  
-`"condition": [["servicedata", 25, "4", "&" "servicedata", 26, "5"], "|", "servicedata", 30, "ABCD"]`  
-This will result in a positive detection if the service data at index `25` == `4` and the service data at index `26` == `5`, otherwise, if the service data at index `30` == `0xABCD`, the result will also be positive.
+`"condition": [["servicedata", 25, "4", "&" "servicedata", 26, "5"], "|", "servicedata", 30, "abcd"]`  
+This will result in a positive detection if the service data at index `25` == `4` and the service data at index `26` == `5`, otherwise, if the service data at index `30` == `0xabcd`, the result will also be positive.
 
 ::: warning Note
 Nesting is discouraged from use wherever possible as the recursive nature may cause stack overflowing in some circumstances.  
 The above example could be re-written as:  
-`"condition": ["servicedata", 30, "ABCD", "|", "servicedata", 25, "4", "&" "servicedata", 5, "5"]`  
+`"condition": ["servicedata", 30, "abcd", "|", "servicedata", 25, "4", "&" "servicedata", 5, "5"]`  
 Which has the same result, without nesting.
 :::
 


### PR DESCRIPTION
Lower casing examples in the docs for clarification, as this is how servicedata and manufacturerdata are being reported and upper case condition comparisons fail.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
