### PR TITLE
Fix units for TPMS and JQJCY01YM

### DIFF
--- a/docs/devices/HHCCPOT002.md
+++ b/docs/devices/HHCCPOT002.md
@@ -7,6 +7,6 @@
 |Short Description|Moisture, temperature and fertility sensor|
 |Communication|BLE broadcast|
 |Frequency|2.4Ghz|
-|Power source|CR2032|
+|Power source|Rechargeable battery, USB|
 |Exchanged data|moisture, fertility|
 |Encrypted|No|

--- a/docs/devices/JQJCY01YM.md
+++ b/docs/devices/JQJCY01YM.md
@@ -8,5 +8,5 @@
 |Communication|BLE broadcast|
 |Frequency|2.4Ghz|
 |Power source|2 AA|
-|Exchanged data|formaldehyde, humidity, battery|
+|Exchanged data|formaldehyde, temperature, humidity, battery|
 |Encrypted|No|

--- a/src/devices/JQJCY01YM_json.h
+++ b/src/devices/JQJCY01YM_json.h
@@ -28,7 +28,7 @@ const char* _JQJCY01YM_json = "{\"brand\":\"Xiaomi\",\"model\":\"Formaldehyde de
    }
 })"""";*/
 
-const char* _JQJCY01YM_json_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"for\":{\"unit\":\"%\",\"name\":\"formaldehyde\"}}}";
+const char* _JQJCY01YM_json_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"for\":{\"unit\":\"mg/m³\",\"name\":\"formaldehyde\"}}}";
 /*R""""(
 {
    "properties":{
@@ -45,7 +45,7 @@ const char* _JQJCY01YM_json_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\
          "name":"humidity"
       },
       "for":{
-         "unit":"%",
+         "unit":"mg/m³",
          "name":"formaldehyde"
       }
    }

--- a/src/devices/TPMS_json.h
+++ b/src/devices/TPMS_json.h
@@ -28,7 +28,7 @@ const char* _TPMS_json = "{\"brand\":\"GENERIC\",\"model\":\"TPMS\",\"model_id\"
    }
 })"""";*/
 
-const char* _TPMS_json_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"kPa\",\"name\":\"temperature\"},\"count\":{\"unit\":\"int\",\"name\":\"count\"},\"alarm\":{\"unit\":\"status\",\"name\":\"alarm\"}}}";
+const char* _TPMS_json_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"kPa\",\"name\":\"pressure\"},\"count\":{\"unit\":\"int\",\"name\":\"count\"},\"alarm\":{\"unit\":\"status\",\"name\":\"alarm\"}}}";
 /*R""""(
 {
    "properties":{
@@ -42,7 +42,7 @@ const char* _TPMS_json_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"name
       },
       "pres":{
          "unit":"kPa",
-         "name":"temperature"
+         "name":"pressure"
       },
       "count":{
          "unit":"int",


### PR DESCRIPTION
## Description:

Fix sensor name for TPMS (pressure name was misidentified as temperature) and unit for JQJCY01YM (formaldehyde unit was misidentified as % instead of mg/m³)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
