### PR TITLE
Docs Links Fixes

### DIFF
--- a/docs/devices/MokoBeacon.md
+++ b/docs/devices/MokoBeacon.md
@@ -1,6 +1,6 @@
 # MokoSmart Beacon
 
-|Model Id|[MokoBeacon](https://github.com/theengs/decoder/blob/development/src/devices/MokoBeacon_json.h)|
+|Model Id|[MokoBeacon](https://github.com/theengs/decoder/blob/development/src/devices/Mokobeacon_json.h)|
 |-|-|
 |Brand|MOKOSMART|
 |Model|Beacon|

--- a/docs/devices/iBeacon.md
+++ b/docs/devices/iBeacon.md
@@ -1,9 +1,9 @@
 # iBeacon
 
-|Model Id|[IBEACON](https://github.com/theengs/decoder/blob/development/src/devices/IBEACON_json.h)|
+|Model Id|[iBeacon](https://github.com/theengs/decoder/blob/development/src/devices/iBeacon_json.h)|
 |-|-|
 |Brand|Generic|
-|Model|Ibeacon|
+|Model|iBeacon|
 |Short Description|Ibeacon protocol|
 |Communication|BLE broadcast|
 |Frequency|2.4Ghz|


### PR DESCRIPTION
Fixes for remaining broken device decoder links

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
