### PR TITLE
Fix TX power unit of iBeacon: dBm instead of int

### DIFF
--- a/src/devices/iBeacon_json.h
+++ b/src/devices/iBeacon_json.h
@@ -31,7 +31,7 @@ const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"mode
    }
 })"""";*/
 
-const char* _ibeacon_json_props = "{\"properties\":{\"mfid\":{\"unit\":\"hex\",\"name\":\"manufacturer id\"},\"uuid\":{\"unit\":\"hex\",\"name\":\"service uuid\"},\"major\":{\"unit\":\"hex\",\"name\":\"major value\"},\"minor\":{\"unit\":\"hex\",\"name\":\"minor value\"},\"power\":{\"unit\":\"int\",\"name\":\"tx power\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"}}}";
+const char* _ibeacon_json_props = "{\"properties\":{\"mfid\":{\"unit\":\"hex\",\"name\":\"manufacturer id\"},\"uuid\":{\"unit\":\"hex\",\"name\":\"service uuid\"},\"major\":{\"unit\":\"hex\",\"name\":\"major value\"},\"minor\":{\"unit\":\"hex\",\"name\":\"minor value\"},\"power\":{\"unit\":\"dBm\",\"name\":\"tx power\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"}}}";
 /*R""""(
 {
    "properties":{
@@ -52,7 +52,7 @@ const char* _ibeacon_json_props = "{\"properties\":{\"mfid\":{\"unit\":\"hex\",\
          "name":"minor value"
       },
       "power":{
-         "unit":"int",
+         "unit":"dBm",
          "name":"tx power"
       },
       "volt":{


### PR DESCRIPTION
## Description:

This fixes the unit of the TX power property of the iBeacon decoder: it should be dBm, not int. I noticed this while looking at Theengs Explorer's output, which shows the property's unit.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
