### PR TITLE
Python build version

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.3)
 
-project(decoder VERSION 0.1.0)
+project(decoder VERSION 0.4.0)
 find_package(PythonExtensions REQUIRED)
 
 add_library(_decoder MODULE TheengsDecoder/_decoder.cpp ../src/decoder.cpp)

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from skbuild import setup
 
 setup(
     name="TheengsDecoder",
-    version="0.1.0",
+    version="0.4.0",
     description="A message decoder for the Internet of Things",
     author='Theengs',
     license=" GPL-3.0 License",


### PR DESCRIPTION
Not sure if we're really too concerned about this, but until Decoder might become a submodule of  Explorer I was just a bit surprised when looking at my pip3 packages

```
…
TheengsDecoder                 0.1.0
TheengsGateway                 0.2.0
…
```

Much more reassuring now with

```
…
TheengsDecoder                 0.4.0
TheengsGateway                 0.2.0
…
```

even if I built the dev branch :)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
