### PR TITLE
Use lowercase names for properties in RuuviTag decoder

### DIFF
--- a/src/devices/RuuviTag_RAWv1_json.h
+++ b/src/devices/RuuviTag_RAWv1_json.h
@@ -36,7 +36,7 @@ const char* _RuuviTag_RAWv1_json = "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",
    }
 })"""";*/
 
-const char* _RuuviTag_RAWv1_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"hPa\",\"name\":\"pressure\"},\"accx\":{\"unit\":\"g\",\"name\":\"accelerationX\"},\"accy\":{\"unit\":\"g\",\"name\":\"accelerationY\"},\"accz\":{\"unit\":\"g\",\"name\":\"accelerationZ\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"}}}";
+const char* _RuuviTag_RAWv1_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"hPa\",\"name\":\"pressure\"},\"accx\":{\"unit\":\"g\",\"name\":\"acceleration x\"},\"accy\":{\"unit\":\"g\",\"name\":\"acceleration y\"},\"accz\":{\"unit\":\"g\",\"name\":\"acceleration z\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"}}}";
 /*R""""(
 {
    "properties":{
@@ -54,15 +54,15 @@ const char* _RuuviTag_RAWv1_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%
       },
       "accx":{
          "unit":"g",
-         "name":"accelerationX"
+         "name":"acceleration x"
       },
       "accy":{
          "unit":"g",
-         "name":"accelerationY"
+         "name":"acceleration y"
       },
       "accz":{
          "unit":"g",
-         "name":"accelerationZ"
+         "name":"acceleration z"
       },
       "volt":{
          "unit":"V",

--- a/src/devices/RuuviTag_RAWv2_json.h
+++ b/src/devices/RuuviTag_RAWv2_json.h
@@ -47,7 +47,7 @@ const char* _RuuviTag_RAWv2_json = "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",
    }
 })"""";*/
 
-const char* _RuuviTag_RAWv2_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"hPa\",\"name\":\"pressure\"},\"accx\":{\"unit\":\"g\",\"name\":\"accelerationX\"},\"accy\":{\"unit\":\"g\",\"name\":\"accelerationY\"},\"accz\":{\"unit\":\"g\",\"name\":\"accelerationZ\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"},\"tx\":{\"unit\":\"dBm\",\"name\":\"tx power\"},\"mov\":{\"unit\":\"int\",\"name\":\"movement counter\"},\"seq\":{\"unit\":\"int\",\"name\":\"measurement sequence number\"}}}";
+const char* _RuuviTag_RAWv2_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"hPa\",\"name\":\"pressure\"},\"accx\":{\"unit\":\"g\",\"name\":\"acceleration x\"},\"accy\":{\"unit\":\"g\",\"name\":\"acceleration y\"},\"accz\":{\"unit\":\"g\",\"name\":\"acceleration z\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"},\"tx\":{\"unit\":\"dBm\",\"name\":\"tx power\"},\"mov\":{\"unit\":\"int\",\"name\":\"movement counter\"},\"seq\":{\"unit\":\"int\",\"name\":\"measurement sequence number\"}}}";
 /*R""""(
 {
    "properties":{

--- a/src/devices/RuuviTag_RAWv2_json.h
+++ b/src/devices/RuuviTag_RAWv2_json.h
@@ -47,7 +47,7 @@ const char* _RuuviTag_RAWv2_json = "{\"brand\":\"Ruuvi\",\"model\":\"RuuviTag\",
    }
 })"""";*/
 
-const char* _RuuviTag_RAWv2_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"hPa\",\"name\":\"pressure\"},\"accx\":{\"unit\":\"g\",\"name\":\"accelerationX\"},\"accy\":{\"unit\":\"g\",\"name\":\"accelerationY\"},\"accz\":{\"unit\":\"g\",\"name\":\"accelerationZ\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"},\"tx\":{\"unit\":\"dBm\",\"name\":\"TX power\"},\"mov\":{\"unit\":\"int\",\"name\":\"movement counter\"},\"seq\":{\"unit\":\"int\",\"name\":\"measurement sequence number\"}}}";
+const char* _RuuviTag_RAWv2_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"pres\":{\"unit\":\"hPa\",\"name\":\"pressure\"},\"accx\":{\"unit\":\"g\",\"name\":\"accelerationX\"},\"accy\":{\"unit\":\"g\",\"name\":\"accelerationY\"},\"accz\":{\"unit\":\"g\",\"name\":\"accelerationZ\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"},\"tx\":{\"unit\":\"dBm\",\"name\":\"tx power\"},\"mov\":{\"unit\":\"int\",\"name\":\"movement counter\"},\"seq\":{\"unit\":\"int\",\"name\":\"measurement sequence number\"}}}";
 /*R""""(
 {
    "properties":{
@@ -65,15 +65,15 @@ const char* _RuuviTag_RAWv2_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%
       },
       "accx":{
          "unit":"g",
-         "name":"accelerationX"
+         "name":"acceleration x"
       },
       "accy":{
          "unit":"g",
-         "name":"accelerationY"
+         "name":"acceleration y"
       },
       "accz":{
          "unit":"g",
-         "name":"accelerationZ"
+         "name":"acceleration z"
       },
       "volt":{
          "unit":"V",
@@ -81,7 +81,7 @@ const char* _RuuviTag_RAWv2_json_props = "{\"properties\":{\"hum\":{\"unit\":\"%
       },
       "tx":{
          "unit":"dBm",
-         "name":"TX power"
+         "name":"tx power"
       },
       "mov":{
          "unit":"int",


### PR DESCRIPTION
## Description:

As mentioned in https://github.com/theengs/decoder/pull/133#issuecomment-1170404577 the RuuviTag decoder has uppercase property names inconsistent with those of other decoders. This PR fixes this.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
