### PR TITLE
SwitchBot Curtain Status Decoder

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -60,6 +60,7 @@ module.exports = {
             'devices/CGPR1',
             'devices/RuuviTag_RAWv1',
             'devices/RuuviTag_RAWv2',
+            'devices/SBCU',
             'devices/SBMT',
             'devices/SBS1',
             'devices/TPMS',

--- a/docs/devices/SBCU.md
+++ b/docs/devices/SBCU.md
@@ -1,0 +1,12 @@
+# SwitchBot Curtain
+
+|Model Id|[W070160X](https://github.com/theengs/decoder/blob/development/src/devices/SBCU_json.h)|
+|-|-|
+|Brand|SwitchBot|
+|Model|Curtain|
+|Short Description|Curtain motor|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|Rechargeable battery|
+|Exchanged data|motion state, position, light level, battery, calibration state|
+|Encrypted|No|

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -81,6 +81,7 @@ public:
     IBT_2X,
     RUUVITAG_RAWV1,
     RUUVITAG_RAWV2,
+    SBCU,
     SBMT,
     SBS1,
     BM_V23,

--- a/src/devices.h
+++ b/src/devices.h
@@ -49,6 +49,7 @@
 #include "devices/Mokobeacon_json.h"
 #include "devices/RuuviTag_RAWv1_json.h"
 #include "devices/RuuviTag_RAWv2_json.h"
+#include "devices/SBCU_json.h"
 #include "devices/SBMT_json.h"
 #include "devices/SBS1_json.h"
 #include "devices/TPMS_json.h"
@@ -98,6 +99,7 @@ const char* _devices[][2] = {
     {_IBT_2X_json, _IBT_2X_json_props},
     {_RuuviTag_RAWv1_json, _RuuviTag_RAWv1_json_props},
     {_RuuviTag_RAWv2_json, _RuuviTag_RAWv2_json_props},
+    {_SBCU_json, _SBCU_json_props},
     {_SBMT_json, _SBMT_json_props},
     {_SBS1_json, _SBS1_json_props},
     {_BM_V23_json, _BM_V23_json_props},

--- a/src/devices/SBCU_json.h
+++ b/src/devices/SBCU_json.h
@@ -1,0 +1,64 @@
+const char* _SBCU_json = "{\"brand\":\"SwitchBot\",\"model\":\"Curtain\",\"model_id\":\"W070160X\",\"condition\":[\"uuid\",\"index\",0,\"0d00\",\"&\",\"servicedata\",\"=\",10,\"index\",0,\"63\"],\"properties\":{\"motion\":{\"decoder\":[\"bit_static_value\",\"servicedata\",6,3,false,true]},\"position\":{\"condition\":[\"servicedata\",6,\"bit\",3,0],\"decoder\":[\"value_from_hex_data\",\"servicedata\",6,2,false,false]},\"_position\":{\"condition\":[\"servicedata\",6,\"bit\",3,1],\"decoder\":[\"value_from_hex_data\",\"servicedata\",6,2,false,false],\"post_proc\":['-',128]},\"calibrated\":{\"decoder\":[\"bit_static_value\",\"servicedata\",2,2,false,true]},\"lightlevel\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,1,false,false]},\"batt\":{\"condition\":[\"servicedata\",4,\"bit\",3,0],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"_batt\":{\"condition\":[\"servicedata\",4,\"bit\",3,1],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false],\"post_proc\":[\"-\",128]}}}";
+/*R""""(
+{
+   "brand":"SwitchBot",
+   "model":"Curtain",
+   "model_id":"W070160X",
+   "condition":["uuid", "index", 0, "0d00", "&", "servicedata", "=", 10, "index", 0, "63"],
+   "properties":{
+      "motion":{
+         "decoder":["bit_static_value", "servicedata", 6, 3, false, true]
+      },
+      "position":{
+         "condition":["servicedata", 6, "bit", 3, 0],
+         "decoder":["value_from_hex_data", "servicedata", 6, 2, false, false]
+      },
+      "_position":{
+         "condition":["servicedata", 6, "bit", 3, 1],
+         "decoder":["value_from_hex_data", "servicedata", 6, 2, false, false],
+         "post_proc":['-', 128]
+      },
+      "calibrated":{
+         "decoder":["bit_static_value", "servicedata", 2, 2, false, true]
+      },
+      "lightlevel":{
+         "decoder":["value_from_hex_data", "servicedata", 8, 1, false, false]
+      },
+      "batt":{
+         "condition":["servicedata", 4, "bit", 3, 0],
+         "decoder":["value_from_hex_data", "servicedata", 4, 2, false, false]
+      },
+      "_batt":{
+         "condition":["servicedata", 4, "bit", 3, 1],
+         "decoder":["value_from_hex_data", "servicedata", 4, 2, false, false],
+         "post_proc":["-", 128]
+      }
+   }
+})"""";*/
+
+const char* _SBCU_json_props = "{\"properties\":{\"motion\":{\"unit\":\"status\",\"name\":\"motion\"},\"position\":{\"unit\":\"%\",\"name\":\"position\"},\"calibrated\":{\"unit\":\"status\",\"name\":\"calibrated\"},\"lightlevel\":{\"unit\":\"int\",\"name\":\"light level\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"}}}";
+/*R""""(
+{
+   "properties":{
+      "motion":{
+         "unit":"status",
+         "name":"motion"
+      },
+      "position":{
+         "unit":"%",
+         "name":"position"
+      },
+      "calibrated":{
+         "unit":"status",
+         "name":"calibrated"
+      },
+      "lightlevel":{
+         "unit":"int",
+         "name":"light level"
+      },
+      "batt":{
+         "unit":"%",
+         "name":"battery"
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -135,6 +135,8 @@ const char* expected_uuid[] = {
     "{\"brand\":\"rbaron\",\"model\":\"b-parasite\",\"model_id\":\"BPv1.0-1.2\",\"tempc\":22.7,\"tempf\":72.86,\"hum\":65.00038148,\"moi\":42.00045777,\"lux\":12500,\"volt\":2.95}",
     "{\"brand\":\"rbaron\",\"model\":\"b-parasite\",\"model_id\":\"BPv1.0-1.2\",\"tempc\":25.6,\"tempf\":78.08,\"hum\":90.00076295,\"moi\":49.99923705,\"volt\":3.1}",
     "{\"brand\":\"rbaron\",\"model\":\"b-parasite\",\"model_id\":\"BPv1.0-1.2\",\"tempc\":22.7,\"tempf\":72.86,\"hum\":65.00038148,\"moi\":42.00045777,\"lux\":12500,\"volt\":2.95}",
+    "{\"brand\":\"SwitchBot\",\"model\":\"Curtain\",\"model_id\":\"W070160X\",\"motion\":false,\"position\":25,\"calibrated\":true,\"lightlevel\":7,\"batt\":76}",
+    "{\"brand\":\"SwitchBot\",\"model\":\"Curtain\",\"model_id\":\"W070160X\",\"motion\":true,\"position\":25,\"calibrated\":false,\"lightlevel\":10,\"batt\":85}",
 };
 
 // Service data test input [test name] [data]
@@ -366,6 +368,8 @@ const char* test_uuid[][4] = {
     {"bParasite", "181a", "servicedata", "11c30b8658aca6666b85aabbccddeeff30d4"},
     {"bParasite", "181a", "servicedata", "20c30c1c0a00e6667fffaabbccddeeff"},
     {"bParasite", "181a", "servicedata", "21c30b8608dea6666b85aabbccddeeff30d4"},
+    {"Switchbot_Curtain", "0d00", "servicedata", "63c04c1970"},
+    {"Switchbot_Curtain", "0d00", "servicedata", "63805599a0"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
@@ -405,6 +409,8 @@ TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
   TheengsDecoder::BLE_ID_NUM::BPARASITE,
   TheengsDecoder::BLE_ID_NUM::BPARASITE,
   TheengsDecoder::BLE_ID_NUM::BPARASITE,
+  TheengsDecoder::BLE_ID_NUM::SBCU,
+  TheengsDecoder::BLE_ID_NUM::SBCU,
 };
 
 template <typename T>


### PR DESCRIPTION
While people with the device seem either afraid or unsure of testing with a test branch we could release this finished SwitchBot Curtain status decoder. With eventual feedback it could then also be possible to implement the writing control of the device in OMG, similar to the Bot.

Please let me know how you feel about this.

Thanks

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
