### PR TITLE
Streamlined iBeacon vs. other iBeacon

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -232,9 +232,9 @@ bool TheengsDecoder::checkDeviceMatch(const JsonArray& condition,
 
       if (strstr(cond_str, "contain") != nullptr) {
         if (strstr(cmp_str, condition[++i].as<const char*>()) != nullptr) {
-          match = (strstr(cond_str, "not_") != nullptr) ? false : true;
+          match = true; // (strstr(cond_str, "not_") != nullptr) ? false : true;
         } else {
-          match = (strstr(cond_str, "not_") != nullptr) ? true : false;
+          match = false; // (strstr(cond_str, "not_") != nullptr) ? true : false;
         }
         i++;
       } else if (strstr(cond_str, "index") != nullptr) {
@@ -340,7 +340,7 @@ bool TheengsDecoder::checkPropCondition(const JsonArray& prop_condition,
         if (strstr((const char*)prop_condition[i + 2], "bit") != nullptr) {
           char ch = *(data_src + prop_condition[i + 1].as<int>());
           uint8_t data = getBinaryData(ch);
-        
+
           uint8_t shift = prop_condition[i + 3].as<uint8_t>();
           uint8_t val = prop_condition[i + 4].as<uint8_t>();
           if (((data >> shift) & 0x01) == val) {

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -66,7 +66,6 @@ public:
     TPMS,
     LYWSD03MMC_ATC,
     CGPR1,
-    IBEACON,
     WS02,
     WS08,
     H5055,
@@ -90,6 +89,7 @@ public:
     HHCCPOT002,
     BPARASITE,
     BM2,
+    IBEACON,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -84,7 +84,6 @@ const char* _devices[][2] = {
     {_TPMS_json, _TPMS_json_props},
     {_LYWSD03MMC_ATC_json, _LYWSD03MMC_ATC_props},
     {_CGPR1_json, _CGPR1_json_props},
-    {_ibeacon_json, _ibeacon_json_props},
     {_WS02_json, _WS02_json_props},
     {_WS08_json, _WS08_json_props},
     {_H5055_json, _H5055_json_props},
@@ -108,4 +107,5 @@ const char* _devices[][2] = {
     {_HHCCPOT002_json, _HHCCPOT002_json_props},
     {_BPARASITE_json, _BPARASITE_json_props},
     {_BM2_json, _BM2_json_props},
+    {_ibeacon_json, _ibeacon_json_props},
 };

--- a/src/devices/BM2_json.h
+++ b/src/devices/BM2_json.h
@@ -1,11 +1,11 @@
-const char* _BM2_json = "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c00\",\"&\",\"name\",\"index\",0,\"Battery Monitor\"],\"properties\":{\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2]}}}";
+const char* _BM2_json = "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"condition\":[\"manufacturerdata\",\"=\",50,\"&\",\"name\",\"index\",0,\"Battery Monitor\"],\"properties\":{\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2]}}}";
 
 /*R""""(
 {
    "brand":"GENERIC",
    "model":"BM2 Battery Monitor",
    "model_id":"BM2",
-   "condition":["manufacturerdata", "=", 50, "index", 0, "4c00", "&", "name", "index", 0, "Battery Monitor"],
+   "condition":["manufacturerdata", "=", 50, "&", "name", "index", 0, "Battery Monitor"],
    "properties":{
       "batt":{
          "decoder":["value_from_hex_data", "manufacturerdata", 48, 2]

--- a/src/devices/iBeacon_json.h
+++ b/src/devices/iBeacon_json.h
@@ -1,11 +1,11 @@
-const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"model_id\":\"IBEACON\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c00\",\"&\",\"name\",\"not_contain\",\"Battery Monitor\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"txpower\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,1],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]},\"volt\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,0],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false],\"post_proc\":[\"/\",10]}}}";
+const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"model_id\":\"IBEACON\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c00\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"txpower\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,1],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]},\"volt\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,0],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
    "brand":"GENERIC",
    "model":"iBeacon",
    "model_id":"IBEACON",
-   "condition":["manufacturerdata", "=", 50, "index", 0, "4c00", "&", "name", "not_contain", "Battery Monitor"],
+   "condition":["manufacturerdata", "=", 50, "index", 0, "4c00"],
    "properties":{
       "mfid":{
          "decoder":["string_from_hex_data", "manufacturerdata", 0, 4]

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -540,7 +540,9 @@ int main() {
       serializeJson(doc_exp, std::cout);
       std::cout << std::endl;
     } else {
-      std::cout << "FAILED! Error parsing: " << test_mfgdata[i][0] << " : " << test_mfgdata[i][1] << " : " << test_mfgdata[i][2] << std::endl;
+      std::cout << "FAILED! Error parsing: " << test_mfgdata[i][0]
+                << " : " << test_mfgdata[i][1] << " : "
+                << test_mfgdata[i][2] << "decode res: " << decode_res << std::endl;
       return 1;
     }
   }


### PR DESCRIPTION
Streamlined iBeacon vs. other iBeacon protocol decoders solution, without using congestion prone `not_contain`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
