### PR TITLE
Add service UUID to condition of LYWSD02 decoder

### DIFF
--- a/src/devices/LYWSD02_json.h
+++ b/src/devices/LYWSD02_json.h
@@ -1,12 +1,12 @@
 #include "common_props.h"
 
-const char* _LYWSD02_json = "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"condition\":[\"servicedata\",\"index\",4,\"5b04\"],\"properties\":{\"tempc\":{\"condition\":[\"servicedata\",24,\"0410\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true],\"post_proc\":[\"/\",10]},\"hum\":{\"condition\":[\"servicedata\",24,\"0610\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"condition\":[\"servicedata\",24,\"0a10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,2,false,false]}}}";
+const char* _LYWSD02_json = "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"condition\":[\"uuid\",\"index\",0,\"fe95\",\"&\",\"servicedata\",\"index\",4,\"5b04\"],\"properties\":{\"tempc\":{\"condition\":[\"servicedata\",24,\"0410\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true],\"post_proc\":[\"/\",10]},\"hum\":{\"condition\":[\"servicedata\",24,\"0610\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"condition\":[\"servicedata\",24,\"0a10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,2,false,false]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
    "model":"Cleargrass clock",
    "model_id":"LYWSD02",
-   "condition":["servicedata", "index", 4, "5b04"],
+   "condition":["uuid", "index", 0, "fe95", "&", "servicedata", "index", 4, "5b04"],
    "properties":{
       "tempc":{
          "condition":["servicedata", 24, "0410"],

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -10,10 +10,6 @@ const char* expected_servicedata[] = {
     "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"tempc\":32,\"tempf\":89.6}",
     "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"fer\":0}",
     "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"tempc\":32,\"tempf\":89.6}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"tempc\":25.6,\"tempf\":78.08}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"hum\":69}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"tempc\":26.5,\"tempf\":79.7}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"batt\":8}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi Jia round\",\"model_id\":\"LYWSDCGQ\",\"tempc\":26,\"tempf\":78.8,\"hum\":61.4}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi Jia round\",\"model_id\":\"LYWSDCGQ\",\"hum\":61.4}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi Jia round\",\"model_id\":\"LYWSDCGQ\",\"batt\":81}",
@@ -138,6 +134,10 @@ const char* expected_uuid[] = {
     "{\"brand\":\"rbaron\",\"model\":\"b-parasite\",\"model_id\":\"BPv1.0-1.2\",\"tempc\":22.7,\"tempf\":72.86,\"hum\":65.00038148,\"moi\":42.00045777,\"lux\":12500,\"volt\":2.95}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Curtain\",\"model_id\":\"W070160X\",\"motion\":false,\"position\":25,\"calibrated\":true,\"lightlevel\":7,\"batt\":76}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Curtain\",\"model_id\":\"W070160X\",\"motion\":true,\"position\":25,\"calibrated\":false,\"lightlevel\":10,\"batt\":85}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"tempc\":25.6,\"tempf\":78.08}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"hum\":69}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"tempc\":26.5,\"tempf\":79.7}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"batt\":8}",
 };
 
 // Service data test input [test name] [data]
@@ -147,10 +147,6 @@ const char* test_servicedata[][2] = {
     {"Mi flora", "712098000163b6658d7cc40d0410024001"},
     {"Mi flora", "712098000863b6658d7cc40d0910020000"},
     {"VegTrug flora", "712098000163b6658d7cc40d0410024001"},
-    {"Cleargrass clock", "70205b04756ab883c8593f090410020001"},
-    {"Cleargrass clock", "70205b04dc6ab883c8593f09061002b202"},
-    {"Cleargrass clock", "70205b04756ab883c8593f090410020901"},
-    {"Cleargrass clock", "70205b04859638b1002ee7090a100108"},
     {"Mi jia round sensor", "5020aa0137dfaa33342d580d100404016602"},
     {"Mi jia round sensor", "5020aa018ddfaa33342d580610026602"},
     {"Mi jia round sensor", "5020aa0155aabbccddeeff0a100151"},
@@ -192,10 +188,6 @@ TheengsDecoder::BLE_ID_NUM test_svcdata_id_num[]{
   TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
   TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
   TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-  TheengsDecoder::BLE_ID_NUM::LYWSD02,
-  TheengsDecoder::BLE_ID_NUM::LYWSD02,
-  TheengsDecoder::BLE_ID_NUM::LYWSD02,
-  TheengsDecoder::BLE_ID_NUM::LYWSD02,
   TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
   TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
   TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
@@ -373,6 +365,10 @@ const char* test_uuid[][4] = {
     {"bParasite", "181a", "servicedata", "21c30b8608dea6666b85aabbccddeeff30d4"},
     {"Switchbot_Curtain", "0d00", "servicedata", "63c04c1970"},
     {"Switchbot_Curtain", "0d00", "servicedata", "63805599a0"},
+    {"Cleargrass clock", "fe95", "servicedata", "70205b04756ab883c8593f090410020001"},
+    {"Cleargrass clock", "fe95", "servicedata", "70205b04dc6ab883c8593f09061002b202"},
+    {"Cleargrass clock", "fe95", "servicedata", "70205b04756ab883c8593f090410020901"},
+    {"Cleargrass clock", "fe95", "servicedata", "70205b04859638b1002ee7090a100108"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
@@ -414,6 +410,10 @@ TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
   TheengsDecoder::BLE_ID_NUM::BPARASITE,
   TheengsDecoder::BLE_ID_NUM::SBCU,
   TheengsDecoder::BLE_ID_NUM::SBCU,
+  TheengsDecoder::BLE_ID_NUM::LYWSD02,
+  TheengsDecoder::BLE_ID_NUM::LYWSD02,
+  TheengsDecoder::BLE_ID_NUM::LYWSD02,
+  TheengsDecoder::BLE_ID_NUM::LYWSD02,
 };
 
 template <typename T>

--- a/tests/BLE_fail/test_ble_fail.cpp
+++ b/tests/BLE_fail/test_ble_fail.cpp
@@ -8,9 +8,6 @@ const char* test_servicedata[][2] = {
     {"Mi flora", "712098005763b6658d7cc40d0810011e"},
     {"Mi flora", "712098000163b6658d7cc40d0410024001"},
     {"Mi flora", "712098000863b6658d7cc40d0910020000"},
-    {"Cleargrass clock", "70205b04756ab883c8593f090410020001"},
-    {"Cleargrass clock", "70205b04dc6ab883c8593f09061002b202"},
-    {"Cleargrass clock", "70205b04756ab883c8593f090410020901"},
     {"Mi jia round sensor", "5020aa0137dfaa33342d580d100404016602"},
     {"Mi jia round sensor", "5020aa018ddfaa33342d580610026602"},
     {"Cleargrass THP sensor", "08094c0140342d5801040801870207024f2702015c"},
@@ -41,9 +38,6 @@ TheengsDecoder::BLE_ID_NUM test_svcdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
     TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
     TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-    TheengsDecoder::BLE_ID_NUM::LYWSD02,
-    TheengsDecoder::BLE_ID_NUM::LYWSD02,
-    TheengsDecoder::BLE_ID_NUM::LYWSD02,
     TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
     TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
     TheengsDecoder::BLE_ID_NUM::CGP1W,
@@ -85,12 +79,18 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
 // uuid test input [test name] [uuid] [data source] [data]
 const char* test_uuid[][4] = {
     {"MiBand", "fee0", "servicedata", "a21e0000"},
+    {"Cleargrass clock", "fe95", "servicedata", "70205b04756ab883c8593f090410020001"},
+    {"Cleargrass clock", "fe95", "servicedata", "70205b04dc6ab883c8593f09061002b202"},
+    {"Cleargrass clock", "fe95", "servicedata", "70205b04756ab883c8593f090410020901"},
     {"SHOULD FAIL", "fa11", "servicedata", "123456789ABCDEF"},
     {"SHOULD FAIL", "0x181d", "servicedata", "f2a22bb2070103003526"}
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
     TheengsDecoder::BLE_ID_NUM::MIBAND,
+    TheengsDecoder::BLE_ID_NUM::LYWSD02,
+    TheengsDecoder::BLE_ID_NUM::LYWSD02,
+    TheengsDecoder::BLE_ID_NUM::LYWSD02,
     TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL,
     TheengsDecoder::BLE_ID_NUM::XMTZC04HM,
 };


### PR DESCRIPTION
## Description:

This adds a check of the service data UUID to the LYWSD02 decoder, as suggested in https://github.com/theengs/decoder/pull/146.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
