### PR TITLE
Narrow down conditions for Mi Flora decoder

### DIFF
--- a/src/devices/HHCCJCY01HHCC_json.h
+++ b/src/devices/HHCCJCY01HHCC_json.h
@@ -1,26 +1,26 @@
-const char* _HHCCJCY01HHCC_json = "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"condition\":[\"servicedata\",\"index\",2,\"209800\",\"|\",\"servicedata\",\"index\",2,\"20bc03\"],\"properties\":{\"tempc\":{\"condition\":[\"servicedata\",25,\"4\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true],\"post_proc\":[\"/\",10]},\"moi\":{\"condition\":[\"servicedata\",25,\"8\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,2,false]},\"lux\":{\"condition\":[\"servicedata\",25,\"7\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,6,true]},\"fer\":{\"condition\":[\"servicedata\",25,\"9\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true]}}}";
+const char* _HHCCJCY01HHCC_json = "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"condition\":[\"uuid\",\"index\",0,\"fe95\",\"&\",\"servicedata\",\"index\",4,\"9800\",\"|\",\"servicedata\",\"index\",4,\"bc03\"],\"properties\":{\"tempc\":{\"condition\":[\"servicedata\",24,\"0410\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true],\"post_proc\":[\"/\",10]},\"moi\":{\"condition\":[\"servicedata\",24,\"0810\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,2,false]},\"lux\":{\"condition\":[\"servicedata\",24,\"0710\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,6,true]},\"fer\":{\"condition\":[\"servicedata\",24,\"0910\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true]}}}";
 /*R""""(
 {
    "brand":"Xiaomi/VegTrug",
    "model":"MiFlora",
    "model_id":"HHCCJCY01HHCC",
-   "condition":["servicedata", "index", 2, "209800", "|", "servicedata", "index", 2, "20bc03"],
+   "condition":["uuid", "index", 0, "fe95", "&", "servicedata", "index", 4, "9800", "|", "servicedata", "index", 4, "bc03"],
    "properties":{
       "tempc":{
-         "condition":["servicedata", 25, "4"],
+         "condition":["servicedata", 24, "0410"],
          "decoder":["value_from_hex_data", "servicedata", 30, 4, true],
          "post_proc":["/", 10]
       },
       "moi":{
-         "condition":["servicedata", 25, "8"],
+         "condition":["servicedata", 24, "0810"],
          "decoder":["value_from_hex_data", "servicedata", 30, 2, false]
       },
       "lux":{
-         "condition":["servicedata", 25, "7"],
+         "condition":["servicedata", 24, "0710"],
          "decoder":["value_from_hex_data", "servicedata", 30, 6, true]
       },
       "fer":{
-         "condition":["servicedata", 25, "9"],
+         "condition":["servicedata", 24, "0910"],
          "decoder":["value_from_hex_data", "servicedata", 30, 4, true]
       }
    }

--- a/src/devices/HHCCJCY01HHCC_json.h
+++ b/src/devices/HHCCJCY01HHCC_json.h
@@ -1,10 +1,10 @@
-const char* _HHCCJCY01HHCC_json = "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"condition\":[\"uuid\",\"index\",0,\"fe95\",\"&\",\"servicedata\",\"index\",4,\"9800\",\"|\",\"servicedata\",\"index\",4,\"bc03\"],\"properties\":{\"tempc\":{\"condition\":[\"servicedata\",24,\"0410\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true],\"post_proc\":[\"/\",10]},\"moi\":{\"condition\":[\"servicedata\",24,\"0810\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,2,false]},\"lux\":{\"condition\":[\"servicedata\",24,\"0710\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,6,true]},\"fer\":{\"condition\":[\"servicedata\",24,\"0910\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true]}}}";
+const char* _HHCCJCY01HHCC_json = "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"condition\":[\"servicedata\",\"index\",4,\"9800\",\"|\",\"servicedata\",\"index\",4,\"bc03\",\"&\",\"uuid\",\"index\",0,\"fe95\"],\"properties\":{\"tempc\":{\"condition\":[\"servicedata\",24,\"0410\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true],\"post_proc\":[\"/\",10]},\"moi\":{\"condition\":[\"servicedata\",24,\"0810\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,2,false]},\"lux\":{\"condition\":[\"servicedata\",24,\"0710\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,6,true]},\"fer\":{\"condition\":[\"servicedata\",24,\"0910\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",30,4,true]}}}";
 /*R""""(
 {
    "brand":"Xiaomi/VegTrug",
    "model":"MiFlora",
    "model_id":"HHCCJCY01HHCC",
-   "condition":["uuid", "index", 0, "fe95", "&", "servicedata", "index", 4, "9800", "|", "servicedata", "index", 4, "bc03"],
+   "condition":["servicedata", "index", 4, "9800", "|", "servicedata", "index", 4, "bc03", "&", "uuid", "index", 0, "fe95"],
    "properties":{
       "tempc":{
          "condition":["servicedata", 24, "0410"],

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -5,11 +5,6 @@
 #include "decoder.h"
 
 const char* expected_servicedata[] = {
-    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"lux\":9971}",
-    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"moi\":30}",
-    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"tempc\":32,\"tempf\":89.6}",
-    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"fer\":0}",
-    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"tempc\":32,\"tempf\":89.6}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi Jia round\",\"model_id\":\"LYWSDCGQ\",\"tempc\":26,\"tempf\":78.8,\"hum\":61.4}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi Jia round\",\"model_id\":\"LYWSDCGQ\",\"hum\":61.4}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi Jia round\",\"model_id\":\"LYWSDCGQ\",\"batt\":81}",
@@ -138,15 +133,15 @@ const char* expected_uuid[] = {
     "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"hum\":69}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"tempc\":26.5,\"tempf\":79.7}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Cleargrass clock\",\"model_id\":\"LYWSD02\",\"batt\":8}",
+    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"lux\":9971}",
+    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"moi\":30}",
+    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"tempc\":32,\"tempf\":89.6}",
+    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"fer\":0}",
+    "{\"brand\":\"Xiaomi/VegTrug\",\"model\":\"MiFlora\",\"model_id\":\"HHCCJCY01HHCC\",\"tempc\":32,\"tempf\":89.6}",
 };
 
 // Service data test input [test name] [data]
 const char* test_servicedata[][2] = {
-    {"Mi flora", "712098004a63b6658d7cc40d071003f32600"},
-    {"Mi flora", "712098005763b6658d7cc40d0810011e"},
-    {"Mi flora", "712098000163b6658d7cc40d0410024001"},
-    {"Mi flora", "712098000863b6658d7cc40d0910020000"},
-    {"VegTrug flora", "712098000163b6658d7cc40d0410024001"},
     {"Mi jia round sensor", "5020aa0137dfaa33342d580d100404016602"},
     {"Mi jia round sensor", "5020aa018ddfaa33342d580610026602"},
     {"Mi jia round sensor", "5020aa0155aabbccddeeff0a100151"},
@@ -183,11 +178,6 @@ const char* test_servicedata[][2] = {
 };
 
 TheengsDecoder::BLE_ID_NUM test_svcdata_id_num[]{
-  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
   TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
   TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
   TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
@@ -369,6 +359,11 @@ const char* test_uuid[][4] = {
     {"Cleargrass clock", "fe95", "servicedata", "70205b04dc6ab883c8593f09061002b202"},
     {"Cleargrass clock", "fe95", "servicedata", "70205b04756ab883c8593f090410020901"},
     {"Cleargrass clock", "fe95", "servicedata", "70205b04859638b1002ee7090a100108"},
+    {"Mi flora", "fe95", "servicedata", "712098004a63b6658d7cc40d071003f32600"},
+    {"Mi flora", "fe95", "servicedata", "712098005763b6658d7cc40d0810011e"},
+    {"Mi flora", "fe95", "servicedata", "712098000163b6658d7cc40d0410024001"},
+    {"Mi flora", "fe95", "servicedata", "712098000863b6658d7cc40d0910020000"},
+    {"VegTrug flora", "fe95", "servicedata", "712098000163b6658d7cc40d0410024001"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
@@ -414,6 +409,11 @@ TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
   TheengsDecoder::BLE_ID_NUM::LYWSD02,
   TheengsDecoder::BLE_ID_NUM::LYWSD02,
   TheengsDecoder::BLE_ID_NUM::LYWSD02,
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+  TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
 };
 
 template <typename T>

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -363,7 +363,7 @@ const char* test_uuid[][4] = {
     {"Mi flora", "fe95", "servicedata", "712098005763b6658d7cc40d0810011e"},
     {"Mi flora", "fe95", "servicedata", "712098000163b6658d7cc40d0410024001"},
     {"Mi flora", "fe95", "servicedata", "712098000863b6658d7cc40d0910020000"},
-    {"VegTrug flora", "fe95", "servicedata", "712098000163b6658d7cc40d0410024001"},
+    {"VegTrug flora", "fe95", "servicedata", "7120bc030163b6658d7cc40d0410024001"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{

--- a/tests/BLE_fail/test_ble_fail.cpp
+++ b/tests/BLE_fail/test_ble_fail.cpp
@@ -4,10 +4,6 @@
 
 // Service data test input [test name] [data]
 const char* test_servicedata[][2] = {
-    {"Mi flora", "712098004a63b6658d7cc40d071003f32600"},
-    {"Mi flora", "712098005763b6658d7cc40d0810011e"},
-    {"Mi flora", "712098000163b6658d7cc40d0410024001"},
-    {"Mi flora", "712098000863b6658d7cc40d0910020000"},
     {"Mi jia round sensor", "5020aa0137dfaa33342d580d100404016602"},
     {"Mi jia round sensor", "5020aa018ddfaa33342d580610026602"},
     {"Cleargrass THP sensor", "08094c0140342d5801040801870207024f2702015c"},
@@ -34,10 +30,6 @@ const char* test_servicedata[][2] = {
 };
 
 TheengsDecoder::BLE_ID_NUM test_svcdata_id_num[]{
-    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
-    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
     TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
     TheengsDecoder::BLE_ID_NUM::LYWSDCGQ,
     TheengsDecoder::BLE_ID_NUM::CGP1W,
@@ -82,6 +74,10 @@ const char* test_uuid[][4] = {
     {"Cleargrass clock", "fe95", "servicedata", "70205b04756ab883c8593f090410020001"},
     {"Cleargrass clock", "fe95", "servicedata", "70205b04dc6ab883c8593f09061002b202"},
     {"Cleargrass clock", "fe95", "servicedata", "70205b04756ab883c8593f090410020901"},
+    {"Mi flora", "fe95", "servicedata", "712098004a63b6658d7cc40d071003f32600"},
+    {"Mi flora", "fe95", "servicedata", "712098005763b6658d7cc40d0810011e"},
+    {"Mi flora", "fe95", "servicedata", "712098000163b6658d7cc40d0410024001"},
+    {"Mi flora", "fe95", "servicedata", "712098000863b6658d7cc40d0910020000"},
     {"SHOULD FAIL", "fa11", "servicedata", "123456789ABCDEF"},
     {"SHOULD FAIL", "0x181d", "servicedata", "f2a22bb2070103003526"}
 };
@@ -91,6 +87,10 @@ TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
     TheengsDecoder::BLE_ID_NUM::LYWSD02,
     TheengsDecoder::BLE_ID_NUM::LYWSD02,
     TheengsDecoder::BLE_ID_NUM::LYWSD02,
+    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
+    TheengsDecoder::BLE_ID_NUM::HHCCJCY01HHCC,
     TheengsDecoder::BLE_ID_NUM::UNKNOWN_MODEL,
     TheengsDecoder::BLE_ID_NUM::XMTZC04HM,
 };


### PR DESCRIPTION
## Description:

This narrows down the conditions for the Mi Flora decoder, as suggested in https://github.com/theengs/decoder/pull/147. I don't have the model with product ID bc03 to check, but for my own devices it works and I adapted the tests to take into account the UUID too.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
