### PR TITLE
CGH1 panic fix!?!

### DIFF
--- a/src/devices/CGH1_json.h
+++ b/src/devices/CGH1_json.h
@@ -17,11 +17,12 @@ const char* _CGH1_json = "{\"brand\":\"Qingping\",\"model\":\"Door sensor\",\"mo
    }
 })"""";*/
 
-const char* _CGH1_json_props = "{\"properties\":{\"open\":{\"name\":\"door\"}}}";
+const char* _CGH1_json_props = "{\"properties\":{\"open\":{\"unit\":\"status\",\"name\":\"door\"}}}";
 /*R""""(
 {
    "properties":{
       "open":{
+         "unit":"status",
          "name":"door"
       }
    }


### PR DESCRIPTION
https://community.openmqttgateway.com/t/qingping-cgh1-panic/1954/4

It has always puzzled me a bit why this property never had a unit, but since it never caused any issues with the test runs … but adding a unit fixed the panic the forum user experienced.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
