### PR TITLE
XCode-macOS-actions

### DIFF
--- a/.github/workflows/PR_build.yml
+++ b/.github/workflows/PR_build.yml
@@ -77,12 +77,12 @@ jobs:
   xcode:
     name: XCode
     needs: clang
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
         include:
-          - xcode: "12.4"
+          - xcode: "13.2.1"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
   xcode:
     name: XCode
     needs: clang
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +123,7 @@ jobs:
           - xcode: "10.3"
           - xcode: "11.7"
           - xcode: "12.4"
+          - xcode: "13.2.1"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Update for Xcode-macOS-action to **macos-11** and **xcode: "13.2.1"**

> 
> XCode (12.4)
>     This is a scheduled macOS-10.15 brownout. The macOS-10.15 environment is deprecated and will be removed on August 30th, 2022. 
> 
> PR_Build: .github#L1
>     The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
