### PR TITLE
hirsute eol deletion

### DIFF
--- a/.github/workflows/PR_build.yml
+++ b/.github/workflows/PR_build.yml
@@ -20,7 +20,6 @@ jobs:
           sudo add-apt-repository -yn 'deb http://archive.ubuntu.com/ubuntu/ xenial universe' 
           sudo add-apt-repository -yn 'deb http://archive.ubuntu.com/ubuntu/ bionic main'
           sudo add-apt-repository -yn 'deb http://archive.ubuntu.com/ubuntu/ bionic universe' 
-          sudo add-apt-repository -yn 'deb http://mirrors.kernel.org/ubuntu hirsute main universe' 
           sudo apt-get update
           sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
           sudo add-apt-repository -yn 'deb http://archive.ubuntu.com/ubuntu/ xenial universe' 
           sudo add-apt-repository -yn 'deb http://archive.ubuntu.com/ubuntu/ bionic main'
           sudo add-apt-repository -yn 'deb http://archive.ubuntu.com/ubuntu/ bionic universe' 
-          sudo add-apt-repository -yn 'deb http://mirrors.kernel.org/ubuntu hirsute main universe' 
           sudo apt-get update
           sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
       - name: Checkout


### PR DESCRIPTION
Deleting the inclusion of Ubuntu 21.04 hirsute, `which has been end of life since January 2022`

https://github.com/theengs/decoder/pull/158#issuecomment-1193091134

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
