### PR TITLE
Amazfit inclusion in Mi Band

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -34,6 +34,7 @@ module.exports = {
           title: '1 - Devices 🌡️',   // required
           sidebarDepth: 1,    // optional, defaults to 1
           children: [
+            'devices/Amazfit',
             'devices/BM_V23',
             'devices/BPARASITE',
             'devices/BM2',

--- a/docs/devices/Amazfit.md
+++ b/docs/devices/Amazfit.md
@@ -1,0 +1,12 @@
+# Amazfit Smart Watch
+
+|Model Id|[Amazfit](https://github.com/theengs/decoder/blob/development/src/devices/Miband_json.h)|
+|-|-|
+|Brand|Amazfit|
+|Model|Smart Watch|
+|Short Description|Various Amazfit Smart Watch models with step count and activity heart rate monitoring|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|Rechargeable battery|
+|Exchanged data|steps, activity heart rate (when activated in the Zepp Life settings)|
+|Encrypted|No|

--- a/docs/devices/Miband.md
+++ b/docs/devices/Miband.md
@@ -7,6 +7,6 @@
 |Short Description|Fitness band with step count and activity heart rate monitoring|
 |Communication|BLE broadcast|
 |Frequency|2.4Ghz|
-|Power source|Battery|
-|Exchanged data|steps, activity heart rate|
+|Power source|Rechargeable battery|
+|Exchanged data|steps, activity heart rate (when activated in the Zepp Life settings)|
 |Encrypted|No|

--- a/src/devices/Miband_json.h
+++ b/src/devices/Miband_json.h
@@ -1,9 +1,9 @@
-const char* _Miband_json = "{\"brand\":\"Xiaomi\",\"model\":\"Miband\",\"model_id\":\"MiBand\",\"condition\":[\"uuid\",\"contain\",\"fee0\"],\"properties\":{\"steps\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",0,4,true,false]},\"act_bpm\":{\"condition\":[\"manufacturerdata\",10,\"!\",\"f\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,false]}}}";
+const char* _Miband_json = "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"condition\":[\"uuid\",\"contain\",\"fee0\"],\"properties\":{\"steps\":{\"decoder\":[\"value_from_hex_data\",\"servicedata\",0,4,true,false]},\"act_bpm\":{\"condition\":[\"manufacturerdata\",10,\"!\",\"f\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,false]}}}";
 /*R""""(
 {
-   "brand":"Xiaomi",
-   "model":"Miband",
-   "model_id":"MiBand",
+   "brand":"Xiaomi/Amazfit",
+   "model":"Mi Band/Smart Watch",
+   "model_id":"MB/SW",
    "condition":["uuid", "contain", "fee0"],
    "properties":{
       "steps":{

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -88,14 +88,14 @@ const char* expected_mfg[] = {
 };
 
 const char* expected_uuid_mfgsvcdata[] = {
-    "{\"brand\":\"Xiaomi\",\"model\":\"Miband\",\"model_id\":\"MiBand\",\"steps\":9101,\"act_bpm\":125}",
+    "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"steps\":9101,\"act_bpm\":125}",
     "{\"brand\":\"Radioland\",\"model\":\"RDL52832\",\"model_id\":\"RDL52832\",\"mfid\":\"4c00\",\"uuid\":\"fda50693a4e24fb1afcfc6eb07647825\",\"major\":1,\"minor\":2,\"txpower\":-40,\"tempc\":24.2265625,\"tempf\":75.6078125,\"hum\":47.19921875,\"accx\":-0.02,\"accy\":0.01,\"accz\":0.97}",
     "{\"brand\":\"Radioland\",\"model\":\"RDL52832\",\"model_id\":\"RDL52832\",\"mfid\":\"4c00\",\"uuid\":\"fda50693a4e24fb1afcfc6eb07647825\",\"major\":1,\"minor\":2,\"txpower\":-40,\"tempc\":25.296875,\"tempf\":77.534375,\"hum\":58.22265625,\"accx\":0.14,\"accy\":0.09,\"accz\":-0.98}",
     "{\"brand\":\"Radioland\",\"model\":\"RDL52832\",\"model_id\":\"RDL52832\",\"mfid\":\"4c00\",\"uuid\":\"fda50693a4e24fb1afcfc6eb07647825\",\"major\":1,\"minor\":2,\"txpower\":-40,\"tempc\":26.2734375,\"tempf\":79.2921875,\"hum\":61.203125,\"accx\":0.2,\"accy\":-0.96,\"accz\":0.15}",
 };
 
 const char* expected_uuid[] = {
-    "{\"brand\":\"Xiaomi\",\"model\":\"Miband\",\"model_id\":\"MiBand\",\"steps\":7842}",
+    "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"steps\":7842}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi_Smart_Scale\",\"model_id\":\"XMTZC01HM/XMTZC04HM\",\"weighing_mode\":\"person\",\"unit\":\"kg\",\"weight\":61.75}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi_Smart_Scale\",\"model_id\":\"XMTZC01HM/XMTZC04HM\",\"weighing_mode\":\"object\",\"unit\":\"kg\",\"weight\":9.55}",
     "{\"brand\":\"Xiaomi\",\"model\":\"Mi_Smart_Scale\",\"model_id\":\"XMTZC01HM/XMTZC04HM\",\"weighing_mode\":\"person\",\"unit\":\"kg\",\"weight\":61.75}",


### PR DESCRIPTION
From the confirmation of a user in

https://community.openmqttgateway.com/t/beehivemonitoring-com-devices-howto-add-support/1893/10

the Amazfit Smart Watches (Xiaomi subsidiary AFAIK), like the [Amazfit T-Rex Pro ](https://www.amazfit.com/en/t-rex-pro), use the same protocol for Steps and Activity heart Rate. So nice to include them in the supported devices.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
