### PR TITLE
Add cname and setup auto doc publishing on release

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,6 +1,8 @@
 name: Create and publish documentation
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 jobs:
   documentation:
     runs-on: ubuntu-latest
@@ -28,3 +30,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/.vuepress/dist
+          cname: decoder.theengs.io


### PR DESCRIPTION
## Description:
this should enable gh page to keep the custom domain when pushing doc.
As a separate improvement, also activate the documentation publication on release event.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
