### PR TITLE
Inkbird iBBQs no probe(s) fix

### DIFF
--- a/src/devices/IBT_4XS_json.h
+++ b/src/devices/IBT_4XS_json.h
@@ -1,4 +1,4 @@
-const char* _IBT_4XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-4XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",36,\"index\",0,\"00000000\"],\"properties\":{\"tempc\":{\"condition\":[\"manufacturerdata\",20,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"condition\":[\"manufacturerdata\",24,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"condition\":[\"manufacturerdata\",28,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"condition\":[\"manufacturerdata\",32,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_4XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_id\":\"IBT-4XS\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",36,\"index\",0,\"00000000\"],\"properties\":{\"tempc\":{\"condition\":[\"manufacturerdata\",22,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"condition\":[\"manufacturerdata\",26,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"condition\":[\"manufacturerdata\",30,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"condition\":[\"manufacturerdata\",34,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]}}}";
 /*R""""(
 {
    "brand":"Inkbird",
@@ -7,22 +7,22 @@ const char* _IBT_4XS_json = "{\"brand\":\"Inkbird\",\"model\":\"iBBQ\",\"model_i
    "condition":["name", "index", 0, "iBBQ","&","manufacturerdata", "=" ,36 ,"index", 0, "00000000"],
    "properties":{
       "tempc":{
-         "condition":["manufacturerdata", 20, "!", "f6ff"],
+         "condition":["manufacturerdata", 22, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc2":{
-         "condition":["manufacturerdata", 24, "!", "f6ff"],
+         "condition":["manufacturerdata", 26, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc3":{
-         "condition":["manufacturerdata", 28, "!", "f6ff"],
+         "condition":["manufacturerdata", 30, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 28, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc4":{
-         "condition":["manufacturerdata", 32, "!", "f6ff"],
+         "condition":["manufacturerdata", 34, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 32, 4, true, false],
          "post_proc":["/", 10]
       }

--- a/src/devices/IBT_6XS_SOLIS6_json.h
+++ b/src/devices/IBT_6XS_SOLIS6_json.h
@@ -1,4 +1,4 @@
-const char* _IBT_6XS_SOLIS6_json = "{\"brand\":\"Inkbird/Tenergy\",\"model\":\"iBBQ/SOLIS6\",\"model_id\":\"IBT-6XS/SOLIS-6\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",44,\"index\",0,\"00000000\"],\"properties\":{\"tempc\":{\"condition\":[\"manufacturerdata\",20,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"condition\":[\"manufacturerdata\",24,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"condition\":[\"manufacturerdata\",28,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"condition\":[\"manufacturerdata\",32,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"condition\":[\"manufacturerdata\",36,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"condition\":[\"manufacturerdata\",40,\"!\",\"f6ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,true,false],\"post_proc\":[\"/\",10]}}}";
+const char* _IBT_6XS_SOLIS6_json = "{\"brand\":\"Inkbird/Tenergy\",\"model\":\"iBBQ/SOLIS6\",\"model_id\":\"IBT-6XS/SOLIS-6\",\"condition\":[\"name\",\"index\",0,\"iBBQ\",\"&\",\"manufacturerdata\",\"=\",44,\"index\",0,\"00000000\"],\"properties\":{\"tempc\":{\"condition\":[\"manufacturerdata\",22,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,4,true,false],\"post_proc\":[\"/\",10]},\"tempc2\":{\"condition\":[\"manufacturerdata\",26,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"/\",10]},\"tempc3\":{\"condition\":[\"manufacturerdata\",30,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"/\",10]},\"tempc4\":{\"condition\":[\"manufacturerdata\",34,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,4,true,false],\"post_proc\":[\"/\",10]},\"tempc5\":{\"condition\":[\"manufacturerdata\",38,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,4,true,false],\"post_proc\":[\"/\",10]},\"tempc6\":{\"condition\":[\"manufacturerdata\",42,\"!\",\"ff\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,true,false],\"post_proc\":[\"/\",10]}}}";
 /*R""""(
 {
    "brand":"Inkbird/Tenergy",
@@ -7,32 +7,32 @@ const char* _IBT_6XS_SOLIS6_json = "{\"brand\":\"Inkbird/Tenergy\",\"model\":\"i
    "condition":["name", "index", 0, "iBBQ", "&", "manufacturerdata", "=", 44, "index", 0, "00000000"],
    "properties":{
       "tempc":{
-         "condition":["manufacturerdata", 20, "!", "f6ff"],
+         "condition":["manufacturerdata", 22, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 20, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc2":{
-         "condition":["manufacturerdata", 24, "!", "f6ff"],
+         "condition":["manufacturerdata", 26, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 24, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc3":{
-         "condition":["manufacturerdata", 28, "!", "f6ff"],
+         "condition":["manufacturerdata", 30, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 28, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc4":{
-         "condition":["manufacturerdata", 32, "!", "f6ff"],
+         "condition":["manufacturerdata", 34, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 32, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc5":{
-         "condition":["manufacturerdata", 36, "!", "f6ff"],
+         "condition":["manufacturerdata", 38, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 36, 4, true, false],
          "post_proc":["/", 10]
       },
       "tempc6":{
-         "condition":["manufacturerdata", 40, "!", "f6ff"],
+         "condition":["manufacturerdata", 42, "!", "ff"],
          "decoder":["value_from_hex_data", "manufacturerdata", 40, 4, true, false],
          "post_proc":["/", 10]
       }


### PR DESCRIPTION
No probe generalisation for remaining Inkbird BBQ thermometers - related to

https://github.com/theengs/decoder/pull/173

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
