### PR TITLE
Add ABTemp decoder

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -35,6 +35,7 @@ module.exports = {
           title: '1 - Devices 🌡️',   // required
           sidebarDepth: 1,    // optional, defaults to 1
           children: [
+            'devices/ABTemp',
             'devices/Amazfit',
             'devices/BM_V23',
             'devices/BPARASITE',

--- a/docs/devices/ABTemp.md
+++ b/docs/devices/ABTemp.md
@@ -8,5 +8,5 @@
 |Communication|BLE broadcast|
 |Frequency|2.4Ghz|
 |Power source|CR2450|
-|Exchanged data|mfid, uuid, minor, major, battery, temperature, txpower @ 1 m|
+|Exchanged data|mfid, uuid, major, battery, temperature, txpower @ 1 m|
 |Encrypted|No|

--- a/docs/devices/ABTemp.md
+++ b/docs/devices/ABTemp.md
@@ -1,0 +1,12 @@
+# ABTemp 
+
+|Model Id|[ABTemp](https://github.com/theengs/decoder/blob/development/src/devices/ABTemp_json.h)|
+|-|-|
+|Brand|April Brother|
+|Model|ABTemp|
+|Short Description|iBeacon with temperature sensor|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|CR2450|
+|Exchanged data|mfid, uuid, minor, major, battery, temperature, txpower @ 1 m|
+|Encrypted|No|

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -93,6 +93,7 @@ public:
     BPARASITE,
     BM2,
     RDL52832,
+    ABTEMP,
     IBEACON,
     SERVICE_DATA,
     BLE_ID_MAX

--- a/src/devices.h
+++ b/src/devices.h
@@ -61,6 +61,7 @@
 #include "devices/ThermoBeacon_json.h"
 #include "devices/XMTZC04HM_json.h"
 #include "devices/XMTZC05HM_json.h"
+#include "devices/ABTemp_json.h"
 #include "devices/iBeacon_json.h"
 #include "devices/iNodeEM_json.h"
 #include "devices/BM_V23_json.h"
@@ -116,6 +117,7 @@ const char* _devices[][2] = {
     {_BPARASITE_json, _BPARASITE_json_props},
     {_BM2_json, _BM2_json_props},
     {_RDL52832_json, _RDL52832_json_props},
+    {_ABTemp_json, _ABTemp_json_props},
     {_ibeacon_json, _ibeacon_json_props},
     {_ServiceData_json, _ServiceData_json_props},
 };

--- a/src/devices/ABTemp_json.h
+++ b/src/devices/ABTemp_json.h
@@ -1,0 +1,66 @@
+const char* _ABTemp_json = "{\"brand\":\"April Brother\",\"model\":\"ABTemp\",\"model_id\":\"ABTemp\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c000215b5b182c7eab14988aa99b5c1517008d9\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,2,false]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",46,2,false]},\"txpower\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]}}}";
+/*R""""(
+{
+   "brand":"April Brother",
+   "model":"ABTemp",
+   "model_id":"ABTemp",
+   "condition":["manufacturerdata", "=", 50, "index", 0, "4c000215b5b182c7eab14988aa99b5c1517008d9"],
+   "properties":{
+      "mfid":{
+         "decoder":["string_from_hex_data", "manufacturerdata", 0, 4]
+      },
+      "uuid":{
+         "decoder":["string_from_hex_data", "manufacturerdata", 8, 32]
+      },
+      "major":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 40, 4, false]
+      },
+      "minor":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 44, 4, false]
+      },
+      "batt":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 44, 2, false]
+      },
+      "tempc":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 46, 2, false]
+      },
+      "txpower":{
+         "decoder":["value_from_hex_data","manufacturerdata", 48, 2, false]
+      }
+   }
+})"""";*/
+
+const char* _ABTemp_json_props = "{\"properties\":{\"mfid\":{\"unit\":\"hex\",\"name\":\"manufacturer id\"},\"uuid\":{\"unit\":\"hex\",\"name\":\"service uuid\"},\"major\":{\"unit\":\"hex\",\"name\":\"major value\"},\"minor\":{\"unit\":\"hex\",\"name\":\"minor value\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"txpower\":{\"unit\":\"dBm\",\"name\":\"tx power @ 1 m\"}}}";
+/*R""""(
+{
+   "properties":{
+      "mfid":{
+         "unit":"hex",
+         "name":"manufacturer id"
+      },
+      "uuid":{
+         "unit":"hex",
+         "name":"service uuid"
+      },
+      "major":{
+         "unit":"hex",
+         "name":"major value"
+      },
+      "minor":{
+         "unit":"hex",
+         "name":"minor value"
+      },
+      "batt":{
+         "unit":"%",
+         "name":"battery"
+      },
+      "tempc":{
+         "unit":"°C",
+         "name":"temperature"
+      },
+      "txpower":{
+         "unit":"dBm",
+         "name":"tx power @ 1 m"
+      }
+   }
+})"""";*/

--- a/src/devices/ABTemp_json.h
+++ b/src/devices/ABTemp_json.h
@@ -1,4 +1,4 @@
-const char* _ABTemp_json = "{\"brand\":\"April Brother\",\"model\":\"ABTemp\",\"model_id\":\"ABTemp\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c000215b5b182c7eab14988aa99b5c1517008d9\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,2,false]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",46,2,false]},\"txpower\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]}}}";
+const char* _ABTemp_json = "{\"brand\":\"April Brother\",\"model\":\"ABTemp\",\"model_id\":\"ABTemp\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c000215b5b182c7eab14988aa99b5c1517008d9\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,2,false]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",46,2,false]},\"txpower\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]}}}";
 /*R""""(
 {
    "brand":"April Brother",
@@ -15,9 +15,6 @@ const char* _ABTemp_json = "{\"brand\":\"April Brother\",\"model\":\"ABTemp\",\"
       "major":{
          "decoder":["value_from_hex_data", "manufacturerdata", 40, 4, false]
       },
-      "minor":{
-         "decoder":["value_from_hex_data", "manufacturerdata", 44, 4, false]
-      },
       "batt":{
          "decoder":["value_from_hex_data", "manufacturerdata", 44, 2, false]
       },
@@ -30,7 +27,7 @@ const char* _ABTemp_json = "{\"brand\":\"April Brother\",\"model\":\"ABTemp\",\"
    }
 })"""";*/
 
-const char* _ABTemp_json_props = "{\"properties\":{\"mfid\":{\"unit\":\"hex\",\"name\":\"manufacturer id\"},\"uuid\":{\"unit\":\"hex\",\"name\":\"service uuid\"},\"major\":{\"unit\":\"hex\",\"name\":\"major value\"},\"minor\":{\"unit\":\"hex\",\"name\":\"minor value\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"txpower\":{\"unit\":\"dBm\",\"name\":\"tx power @ 1 m\"}}}";
+const char* _ABTemp_json_props = "{\"properties\":{\"mfid\":{\"unit\":\"hex\",\"name\":\"manufacturer id\"},\"uuid\":{\"unit\":\"hex\",\"name\":\"service uuid\"},\"major\":{\"unit\":\"hex\",\"name\":\"major value\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"txpower\":{\"unit\":\"dBm\",\"name\":\"tx power @ 1 m\"}}}";
 /*R""""(
 {
    "properties":{
@@ -45,10 +42,6 @@ const char* _ABTemp_json_props = "{\"properties\":{\"mfid\":{\"unit\":\"hex\",\"
       "major":{
          "unit":"hex",
          "name":"major value"
-      },
-      "minor":{
-         "unit":"hex",
-         "name":"minor value"
       },
       "batt":{
          "unit":"%",

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -94,7 +94,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"cidc\":false,\"tempc\":29.57704544,\"tempf\":85.23868179,\"hum\":55.99645996,\"shake\":false,\"shake_count\":74,\"volt\":2.929,\"wake\":true}",
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"cidc\":false,\"tempc\":29.57704544,\"tempf\":85.23868179,\"hum\":55.99645996,\"shake\":false,\"shake_count\":74,\"volt\":2.929,\"wake\":false}",
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"cidc\":false,\"tempc\":29.57704544,\"tempf\":85.23868179,\"hum\":55.99645996,\"shake\":false,\"shake_count\":74,\"volt\":2.929,\"wake\":false}",
-    "{\"brand\":\"April Brother\",\"model\":\"ABTemp\",\"model_id\":\"ABTemp\",\"mfid\":\"4c00\",\"uuid\":\"b5b182c7eab14988aa99b5c1517008d9\",\"major\":1,\"minor\":25626,\"batt\":100,\"tempc\":26,\"tempf\":78.8,\"txpower\":-59}",
+    "{\"brand\":\"April Brother\",\"model\":\"ABTemp\",\"model_id\":\"ABTemp\",\"mfid\":\"4c00\",\"uuid\":\"b5b182c7eab14988aa99b5c1517008d9\",\"major\":1,\"batt\":100,\"tempc\":26,\"tempf\":78.8,\"txpower\":-59}",
 };
 
 const char* expected_uuid_mfgsvcdata[] = {

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -94,6 +94,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"cidc\":false,\"tempc\":29.57704544,\"tempf\":85.23868179,\"hum\":55.99645996,\"shake\":false,\"shake_count\":74,\"volt\":2.929,\"wake\":true}",
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"cidc\":false,\"tempc\":29.57704544,\"tempf\":85.23868179,\"hum\":55.99645996,\"shake\":false,\"shake_count\":74,\"volt\":2.929,\"wake\":false}",
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"cidc\":false,\"tempc\":29.57704544,\"tempf\":85.23868179,\"hum\":55.99645996,\"shake\":false,\"shake_count\":74,\"volt\":2.929,\"wake\":false}",
+    "{\"brand\":\"April Brother\",\"model\":\"ABTemp\",\"model_id\":\"ABTemp\",\"mfid\":\"4c00\",\"uuid\":\"b5b182c7eab14988aa99b5c1517008d9\",\"major\":1,\"minor\":25626,\"batt\":100,\"tempc\":26,\"tempf\":78.8,\"txpower\":-59}",
 };
 
 const char* expected_uuid_mfgsvcdata[] = {
@@ -290,6 +291,7 @@ const char* test_mfgdata[][3] = {
     {"SmartDry", "Laundry Sensor", "ae01ca9dec4160fc5f424a005207"},
     {"SmartDry", "Laundry Sensor", "ae01ca9dec4160fc5f424a005200"},
     {"SmartDry", "Laundry Sensor", "ae01ca9dec4160fc5f424a005206"},
+    {"ABTemp", "ABTemp", "4c000215b5b182c7eab14988aa99b5c1517008d90001641ac5"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
@@ -346,6 +348,7 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
   TheengsDecoder::BLE_ID_NUM::SMARTDRY,
   TheengsDecoder::BLE_ID_NUM::SMARTDRY,
   TheengsDecoder::BLE_ID_NUM::SMARTDRY,
+  TheengsDecoder::BLE_ID_NUM::ABTEMP,
 };
 
 // uuid test input [test name] [uuid] [manufacturer data] [service data]


### PR DESCRIPTION
## Description:

This adds a decoder for April Brother's [ABTemp](https://wiki.aprbrother.com/en/ABTemp.html) iBeacon with temperature sensor.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
