### PR TITLE
Fix device match conditions when OR cases used with data length.

### DIFF
--- a/src/decoder.h
+++ b/src/decoder.h
@@ -105,7 +105,7 @@ private:
   double      value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true, bool isFloat = false);
   double      bf_value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true, bool isFloat = false);
   bool        data_index_is_valid(const char* str, size_t index, size_t len);
-  int         data_length_is_valid(size_t data_len, size_t default_min, const JsonArray& condition, int idx);
+  bool        data_length_is_valid(size_t data_len, size_t default_min, const JsonArray& condition, int *idx);
   uint8_t     getBinaryData(char ch);
   bool        evaluateDatalength(std::string op, size_t data_len, size_t req_len);
   bool        checkPropCondition(const JsonArray& prop, const char* svc_data, const char* mfg_data);


### PR DESCRIPTION
## Description:
Changes the way data length checking works to account for validation of OR cases when the data length can match in multiple ways.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
