### PR TITLE
TH1 external probe changes

### DIFF
--- a/src/devices/IBS_TH1_json.h
+++ b/src/devices/IBS_TH1_json.h
@@ -1,4 +1,4 @@
-const char* _IBS_TH1_json = "{\"brand\":\"Inkbird\",\"model\":\"TH Sensor\",\"model_id\":\"IBS-TH1\",\"cidc\":false,\"condition\":[\"name\",\"index\",0,\"sps\"],\"properties\":{\"tempc\":{\"condition\":[\"manufacturerdata\",9,\"0\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",0,4,true],\"post_proc\":[\"/\",100]},\"tempc2_ext\":{\"condition\":[\"manufacturerdata\",9,\"!\",\"0\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",0,4,true],\"post_proc\":[\"/\",100]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",4,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,2,false,false]}}}";
+const char* _IBS_TH1_json = "{\"brand\":\"Inkbird\",\"model\":\"TH Sensor\",\"model_id\":\"IBS-TH1\",\"cidc\":false,\"condition\":[\"name\",\"index\",0,\"sps\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",0,4,true],\"post_proc\":[\"/\",100]},\"extprobe\":{\"condition\":[\"manufacturerdata\",9,\"!\",\"0\"],\"decoder\":[\"static_value\",true]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",4,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,2,false,false]}}}";
 /*R""""(
 {
    "brand":"Inkbird",
@@ -8,14 +8,12 @@ const char* _IBS_TH1_json = "{\"brand\":\"Inkbird\",\"model\":\"TH Sensor\",\"mo
    "condition":["name", "index", 0, "sps"],
    "properties":{
       "tempc":{
-         "condition":["manufacturerdata", 9, "0"],
          "decoder":["value_from_hex_data", "manufacturerdata", 0, 4, true],
          "post_proc":["/", 100]
       },
-      "tempc2_ext":{
+      "extprobe":{
          "condition":["manufacturerdata", 9, "!", "0"],
-         "decoder":["value_from_hex_data", "manufacturerdata", 0, 4, true],
-         "post_proc":["/", 100]
+         "decoder":["static_value", true]
       },
       "hum":{
          "decoder":["value_from_hex_data", "manufacturerdata", 4, 4, true, false],
@@ -27,7 +25,7 @@ const char* _IBS_TH1_json = "{\"brand\":\"Inkbird\",\"model\":\"TH Sensor\",\"mo
    }
 })"""";*/
 
-const char* _IBS_TH1_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"tempc2_ext\":{\"unit\":\"°C\",\"name\":\"external probe temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"}}}";
+const char* _IBS_TH1_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"extprobe\":{\"unit\":\"status\",\"name\":\"external probe connected\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"}}}";
 /*R""""(
 {
    "properties":{
@@ -35,9 +33,9 @@ const char* _IBS_TH1_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",
          "unit":"°C",
          "name":"temperature"
       },
-      "tempc2_ext":{
-         "unit":"°C",
-         "name":"external probe temperature"
+      "extprobe":{
+         "unit":"status",
+         "name":"external probe connected"
       },
       "hum":{
          "unit":"%",

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -24,7 +24,7 @@ const char* expected_servicedata[] = {
 
 const char* expected_mfg[] = {
     "{\"brand\":\"Inkbird\",\"model\":\"TH Sensor\",\"model_id\":\"IBS-TH1\",\"cidc\":false,\"tempc\":26.62,\"tempf\":79.916,\"hum\":53.79,\"batt\":89}",
-    "{\"brand\":\"Inkbird\",\"model\":\"TH Sensor\",\"model_id\":\"IBS-TH1\",\"cidc\":false,\"tempc2_ext\":25.44,\"tempf2_ext\":77.792,\"hum\":51.18,\"batt\":48}",
+    "{\"brand\":\"Inkbird\",\"model\":\"TH Sensor\",\"model_id\":\"IBS-TH1\",\"cidc\":false,\"tempc\":25.44,\"tempf\":77.792,\"extprobe\":true,\"hum\":51.18,\"batt\":48}",
     "{\"brand\":\"GENERIC\",\"model\":\"TPMS\",\"model_id\":\"TPMS\",\"cidc\":false,\"count\":1,\"pres\":2.22708,\"tempc\":31.96,\"tempf\":89.528,\"batt\":51,\"alarm\":false}",
     "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"model_id\":\"IBEACON\",\"mfid\":\"4c00\",\"uuid\":\"426c7565436861726d426561636f6e73\",\"major\":3838,\"minor\":4949,\"txpower\":-59}",
     "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"model_id\":\"IBEACON\",\"mfid\":\"4c00\",\"uuid\":\"fda50693a4e24fb1afcfc6eb07647825\",\"major\":1,\"minor\":2,\"volt\":2.6}",


### PR DESCRIPTION
TH1 external probe to reported the same temperature key, but have an additional external probe boolean

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
