### PR TITLE
Ubuntu runners

### DIFF
--- a/.github/workflows/PR_build.yml
+++ b/.github/workflows/PR_build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   gcc:
     name: GCC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +39,7 @@ jobs:
 
   clang:
     name: Clang
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +117,7 @@ jobs:
         run: ctest --output-on-failure -V -C Debug .
 
   examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   gcc:
     name: GCC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +55,7 @@ jobs:
 
   clang:
     name: Clang
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 jobs:
   documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Create the documentation and deploy it to GitHub Pages
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu runners - `ubuntu-latest` to `ubuntu-20.04 `

https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
