### PR TITLE
Fixed format string for size_t-typed variable

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -276,7 +276,7 @@ bool TheengsDecoder::checkDeviceMatch(const JsonArray& condition,
           i++;
         }
 
-        DEBUG_PRINT("comparing value: %s to %s at index %lu\n",
+        DEBUG_PRINT("comparing value: %s to %s at index %zu\n",
                     &cmp_str[cond_index],
                     condition[i].as<const char*>(),
                     cond_index);


### PR DESCRIPTION
## Description:
%zu seems to be the correct format string for size_t-typed variables; size_t implementation is architecture-specific, e.g. unsigned int or long unsigned int.

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
