### PR TITLE
Don't use deprecated method register_detection_callback

### DIFF
--- a/examples/python/ScanAndDecode.py
+++ b/examples/python/ScanAndDecode.py
@@ -38,8 +38,7 @@ def detection_callback(device, advertisement_data):
 
 
 async def main():
-    scanner = BleakScanner()
-    scanner.register_detection_callback(detection_callback)
+    scanner = BleakScanner(detection_callback=detection_callback)
     await scanner.start()
     await asyncio.sleep(5.0)
     await scanner.stop()


### PR DESCRIPTION
## Description:

Changes the deprecated method `register_detection_callback` of the `BleakScanner` class in the Python example.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
