### PR TITLE
iBeacon model restriction

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -256,9 +256,9 @@ bool TheengsDecoder::checkDeviceMatch(const JsonArray& condition,
 
       if (strstr(cond_str, "contain") != nullptr) {
         if (strstr(cmp_str, condition[++i].as<const char*>()) != nullptr) {
-          match = true; // (strstr(cond_str, "not_") != nullptr) ? false : true;
+          match = (strstr(cond_str, "not_") != nullptr) ? false : true;
         } else {
-          match = false; // (strstr(cond_str, "not_") != nullptr) ? true : false;
+          match = (strstr(cond_str, "not_") != nullptr) ? true : false;
         }
         i++;
       } else if (strstr(cond_str, "mac@index") != nullptr) {

--- a/src/devices/iBeacon_json.h
+++ b/src/devices/iBeacon_json.h
@@ -1,4 +1,4 @@
-const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"model_id\":\"IBEACON\",\"tag\":\"06\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c00\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"txpower\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,1],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]},\"volt\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,0],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false],\"post_proc\":[\"/\",10]}}}";
+const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"model_id\":\"IBEACON\",\"tag\":\"06\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c00\",\"&\",\"name\",\"not_contain\",\"Govee\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"txpower\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,1],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]},\"volt\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,0],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
@@ -6,7 +6,7 @@ const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"mode
    "model":"iBeacon",
    "model_id":"IBEACON",
    "tag":"06",
-   "condition":["manufacturerdata", "=", 50, "index", 0, "4c00"],
+   "condition":["manufacturerdata", "=", 50, "index", 0, "4c00", "&", "name", "not_contain", "Govee"],
    "properties":{
       "mfid":{
          "decoder":["string_from_hex_data", "manufacturerdata", 0, 4]

--- a/src/devices/iBeacon_json.h
+++ b/src/devices/iBeacon_json.h
@@ -1,4 +1,4 @@
-const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"model_id\":\"IBEACON\",\"tag\":\"06\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c00\",\"&\",\"name\",\"not_contain\",\"Govee\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"txpower\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,1],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]},\"volt\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,0],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false],\"post_proc\":[\"/\",10]}}}";
+const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"model_id\":\"IBEACON\",\"tag\":\"06\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c00\",\"&\",\"name\",\"not_contain\",\"Govee\",\"&\",\"name\",\"not_contain\",\"GVH\"],\"properties\":{\"mfid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",0,4]},\"uuid\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",8,32]},\"major\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",40,4,false]},\"minor\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",44,4,false]},\"txpower\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,1],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]},\"volt\":{\"condition\":[\"manufacturerdata\",48,\"bit\",3,0],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false],\"post_proc\":[\"/\",10]}}}";
 
 /*R""""(
 {
@@ -6,7 +6,7 @@ const char* _ibeacon_json = "{\"brand\":\"GENERIC\",\"model\":\"iBeacon\",\"mode
    "model":"iBeacon",
    "model_id":"IBEACON",
    "tag":"06",
-   "condition":["manufacturerdata", "=", 50, "index", 0, "4c00", "&", "name", "not_contain", "Govee"],
+   "condition":["manufacturerdata", "=", 50, "index", 0, "4c00", "&", "name", "not_contain", "Govee", "&", "name", "not_contain", "GVH"],
    "properties":{
       "mfid":{
          "decoder":["string_from_hex_data", "manufacturerdata", 0, 4]


### PR DESCRIPTION
iBeacon model restriction to filter other devices' intermittent iBeaon protocol broadcasts with **not_contain** model condition.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
