### PR TITLE
Revert "Enable GAEN and MS CDP through a compiler directive"

### DIFF
--- a/docs/devices/GAEN.md
+++ b/docs/devices/GAEN.md
@@ -1,6 +1,6 @@
 # Google/Apple Exposure Notification
 
-|Model Id|[GAEN](https://github.com/theengs/decoder/blob/development/src/devices/GAEN_json.h)|
+|Model Id|[MS-CDP](https://github.com/theengs/decoder/blob/development/src/devices/GAEN_json.h)|
 |-|-|
 |Brand|Generic|
 |Model|GAEN|
@@ -10,5 +10,3 @@
 |Power source|Dependent on device|
 |Exchanged data|rolling proximity identifier, associated encrypted metadata|
 |Encrypted|Yes|
-
-This decoder is not enable by default, to enable it you need to define `DECODE_RANDOM_MAC_DEVICES true` at build time.

--- a/docs/devices/MS_CDP.md
+++ b/docs/devices/MS_CDP.md
@@ -10,5 +10,3 @@
 |Power source|Dependent on device|
 |Exchanged data|device type, salt, device hash|
 |Encrypted|No|
-
-This decoder is not enable by default, to enable it you need to define `DECODE_RANDOM_MAC_DEVICES true` at build time.

--- a/docs/use/include.md
+++ b/docs/use/include.md
@@ -2,7 +2,7 @@
 
 Call `decodeBLEJson(JsonObject)` with the input being of the Arduino JSON JsonObject type. If the device is known the JsonObject will have the decoded device data added to it.
 
-## Example
+### Example
 Input JsonObject:
 ```
 {
@@ -21,10 +21,6 @@ JsonObject after decoding:
   "tempf":89.6
 }
 ```
-
-## Identifying advertisements following MS-CDP and GAEN protocols
-The decoder can identify advertisements from MS-CDP and GAEN protocols, these decoders are not enable by default. To add them you have to define the following compiler directive:
-`DECODE_RANDOM_MAC_DEVICES true`
 
 ::: tip
 If you are using ArduinoJson library with your project (like TheengsDecoder) you may have to align the ArduinoJson build options into TheengDecoder with it. To do so, go to [decoder.h](https://github.com/theengs/decoder/blob/development/src/decoder.h) and align the flags with your project. In particular you may have to remove `ARDUINOJSON_USE_LONG_LONG=1`.

--- a/examples/ESP32/ScanAndDecode/platformio.ini
+++ b/examples/ESP32/ScanAndDecode/platformio.ini
@@ -18,5 +18,3 @@ monitor_speed = 115200
 lib_deps = 
 	${libraries.arduinojson}
 	${libraries.ble}
-build_flags =
-	'-DDECODE_RANDOM_MAC_DEVICES=true'

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -96,6 +96,8 @@ public:
     BM1IN1,
     BM3IN1,
     BM4IN1,
+    MS_CDP,
+    GAEN,
     HHCCPOT002,
     BPARASITE,
     BWBSDOO,
@@ -112,24 +114,20 @@ public:
     IBEACON,
     SERVICE_DATA,
     JHT_F525,
-#ifdef DECODE_RANDOM_MAC_DEVICES
-    MS_CDP,
-    GAEN,
-#endif
     BLE_ID_MAX
   };
 
 private:
-  void reverse_hex_data(const char* in, char* out, int l);
-  double value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true, bool isFloat = false);
-  double bf_value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true, bool isFloat = false);
-  bool data_index_is_valid(const char* str, size_t index, size_t len);
-  bool data_length_is_valid(size_t data_len, size_t default_min, const JsonArray& condition, int* idx);
-  uint8_t getBinaryData(char ch);
-  bool evaluateDatalength(std::string op, size_t data_len, size_t req_len);
-  bool checkPropCondition(const JsonArray& prop, const char* svc_data, const char* mfg_data);
-  bool checkDeviceMatch(const JsonArray& condition, const char* svc_data, const char* mfg_data,
-                        const char* dev_name, const char* svc_uuid, const char* mac_id);
+  void        reverse_hex_data(const char* in, char* out, int l);
+  double      value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true, bool isFloat = false);
+  double      bf_value_from_hex_string(const char* data_str, int offset, int data_length, bool reverse, bool canBeNegative = true, bool isFloat = false);
+  bool        data_index_is_valid(const char* str, size_t index, size_t len);
+  bool        data_length_is_valid(size_t data_len, size_t default_min, const JsonArray& condition, int *idx);
+  uint8_t     getBinaryData(char ch);
+  bool        evaluateDatalength(std::string op, size_t data_len, size_t req_len);
+  bool        checkPropCondition(const JsonArray& prop, const char* svc_data, const char* mfg_data);
+  bool        checkDeviceMatch(const JsonArray& condition, const char* svc_data, const char* mfg_data,
+                               const char* dev_name, const char* svc_uuid, const char* mac_id);
   std::string sanitizeJsonKey(const char* key_in);
 
   size_t m_docMax = 12000;

--- a/src/devices.h
+++ b/src/devices.h
@@ -19,8 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//#define DECODE_RANDOM_MAC_DEVICES true // Uncomment if you want the decoder to identify devices with random Mac Address like MS CDP and GAEN
-
 #include "devices/CGD1_json.h"
 #include "devices/CGDK2_json.h"
 #include "devices/CGG1_json.h"
@@ -28,6 +26,7 @@
 #include "devices/CGH1_json.h"
 #include "devices/CGP1W_json.h"
 #include "devices/CGPR1_json.h"
+#include "devices/GAEN_json.h"
 #include "devices/H5055_json.h"
 #include "devices/H5072_json.h"
 #include "devices/H5074_json.h"
@@ -44,6 +43,7 @@
 #include "devices/LYWSD03MMC_json.h"
 #include "devices/LYWSDCGQ_json.h"
 #include "devices/MBXPRO_json.h"
+#include "devices/MS_CDP_json.h"
 #include "devices/MUE4094RT_json.h"
 #include "devices/Miband_json.h"
 #include "devices/Mokobeacon_json.h"
@@ -82,11 +82,6 @@
 #include "devices/BM2_json.h"
 #include "devices/ServiceData_json.h"
 #include "devices/JHT_F525_json.h"
-
-#ifdef DECODE_RANDOM_MAC_DEVICES
-#  include "devices/GAEN_json.h"
-#  include "devices/MS_CDP_json.h"
-#endif
 
 const char* _devices[][2] = {
     {_HHCCJCY01HHCC_json, _HHCCJCY01HHCC_json_props},
@@ -139,6 +134,8 @@ const char* _devices[][2] = {
     {_BM1IN1_json, _BM1IN1_json_props},
     {_BM3IN1_json, _BM3IN1_json_props},
     {_BM4IN1_json, _BM4IN1_json_props},
+    {_MS_CDP_json, _MS_CDP_json_props},
+    {_GAEN_json, _GAEN_json_props},
     {_HHCCPOT002_json, _HHCCPOT002_json_props},
     {_BPARASITE_json, _BPARASITE_json_props},
     {_BWBSDOO_json, _BWBSDOO_json_props},
@@ -155,8 +152,4 @@ const char* _devices[][2] = {
     {_ibeacon_json, _ibeacon_json_props},
     {_ServiceData_json, _ServiceData_json_props},
     {_JHT_F525_json, _JHT_F525_json_props},
-#ifdef DECODE_RANDOM_MAC_DEVICES
-    {_GAEN_json, _GAEN_json_props},
-    {_MS_CDP_json, _MS_CDP_json_props},
-#endif
 };

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -61,6 +61,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Blue Maestro\",\"model\":\"Tempo Disc\",\"model_id\":\"TD3in1\",\"type\":\"THBX\",\"tempc\":-16.3,\"tempf\":2.66,\"hum\":78.3,\"tempc2_dp\":-19.2,\"tempf2_dp\":-2.56,\"batt\":67}",
     "{\"brand\":\"Blue Maestro\",\"model\":\"Tempo Disc\",\"model_id\":\"TD4in1\",\"type\":\"THBX\",\"tempc\":22.3,\"tempf\":72.14,\"hum\":75.9,\"pres\":1013.5,\"batt\":58}",
     "{\"brand\":\"Blue Maestro\",\"model\":\"Tempo Disc\",\"model_id\":\"TD1in1\",\"type\":\"THB\",\"tempc\":25.2,\"tempf\":77.36,\"batt\":100}",
+    "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"type\":\"UNIQ\",\"device\":\"Windows 10 Desktop\",\"salt\":\"ac6d90ec\",\"hash\":\"0132b3204cd39c7ced3e48436ba15dc6\"}",
     "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"acts\":true,\"batt\":100}",
     "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"acts\":true,\"batt\":68}",
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"type\":\"UNIQ\",\"cidc\":false,\"tempc\":34.210289,\"tempf\":93.5785202,\"hum\":100,\"shake\":82,\"volt\":2.952,\"wake\":true}",
@@ -113,9 +114,6 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Atomax\",\"model\":\"Skale I/II\",\"model_id\":\"SKALE\",\"type\":\"SCALE\",\"cidc\":false,\"weight\":123.9}",
     "{\"brand\":\"Atomax\",\"model\":\"Skale I/II\",\"model_id\":\"SKALE\",\"type\":\"SCALE\",\"cidc\":false,\"weight\":29.6}",
     "{\"brand\":\"Atomax\",\"model\":\"Skale I/II\",\"model_id\":\"SKALE\",\"type\":\"SCALE\",\"cidc\":false,\"weight\":-92.8}",
-#ifdef DECODE_RANDOM_MAC_DEVICES
-    "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"type\":\"UNIQ\",\"device\":\"Windows 10 Desktop\",\"salt\":\"ac6d90ec\",\"hash\":\"0132b3204cd39c7ced3e48436ba15dc6\"}",
-#endif
 };
 
 const char* expected_name_uuid_mfgsvcdata[] = {
@@ -172,6 +170,7 @@ const char* expected_uuid[] = {
     "{\"brand\":\"Mokosmart\",\"model\":\"BeaconX Pro\",\"model_id\":\"MBXPRO\",\"type\":\"ACEL\",\"tempc\":27.4,\"tempf\":81.32,\"hum\":49.4,\"volt\":3.247}",
     "{\"brand\":\"Mokosmart\",\"model\":\"BeaconX Pro\",\"model_id\":\"MBXPRO\",\"type\":\"ACEL\",\"x_axis\":5.3348176,\"y_axis\":14.49815136,\"z_axis\":-1.50630144,\"volt\":3.065}",
     "{\"brand\":\"Mokosmart\",\"model\":\"BeaconX Pro\",\"model_id\":\"MBXPRO\",\"type\":\"ACEL\",\"x_axis\":0.25105024,\"y_axis\":-0.18828768,\"z_axis\":15.75340256,\"volt\":3.065}",
+    "{\"brand\":\"GENERIC\",\"model\":\"GAEN\",\"model_id\":\"GAEN\",\"type\":\"UNIQ\",\"rpi\":\"e7c6d34c71e48baf278bd99be74685bc\",\"aem\":\"a78126ab\"}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Bot\",\"model_id\":\"X1\",\"type\":\"ACTR\",\"acts\":true,\"mode\":\"on/off\",\"state\":\"off\",\"batt\":91}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Bot\",\"model_id\":\"X1\",\"type\":\"ACTR\",\"acts\":true,\"mode\":\"on/off\",\"state\":\"on\",\"batt\":76}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Bot\",\"model_id\":\"X1\",\"type\":\"ACTR\",\"acts\":true,\"mode\":\"onestate\",\"state\":\"on\",\"batt\":91}",
@@ -236,9 +235,6 @@ const char* expected_uuid[] = {
     "{\"brand\":\"BlueCharm\",\"model\":\"Beacon 08\",\"model_id\":\"BC08\",\"type\":\"ACEL\",\"tempc\":-11,\"tempf\":12.2,\"accx\":-107,\"accy\":-407,\"accz\":-896,\"volt\":3.085}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Contact Sensor\",\"model_id\":\"W120150X\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"contact\":\"timeout not closed\",\"movement\":false,\"lightlevel\":\"dark\",\"scopetested\":false,\"in_ct\":1,\"out_ct\":0,\"push_ct\":2,\"batt\":100}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Motion Sensor\",\"model_id\":\"W110150X\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"movement\":false,\"led\":false,\"scopetested\":false,\"sensingdistance\":\"long\",\"lightlevel\":\"bright\",\"batt\":100}",
-#ifdef DECODE_RANDOM_MAC_DEVICES
-    "{\"brand\":\"GENERIC\",\"model\":\"GAEN\",\"model_id\":\"GAEN\",\"type\":\"UNIQ\",\"rpi\":\"e7c6d34c71e48baf278bd99be74685bc\",\"aem\":\"a78126ab\"}",
-#endif
 };
 
 const char* expected_mac_mfg[] = {
@@ -340,6 +336,7 @@ const char* test_mfgdata[][3] = {
     {"BlueMaestro", "TempoDisc 3in1", "330116430e10061eff5d030fff400100"},
     {"BlueMaestro", "TempoDisc 4in1", "33011b3a0e10061e00df02f727970100"},
     {"BlueMaestro", "TempoDisc 1in1", "33010d6402580ad100fc0100"},
+    {"MS-CDP", "Windows 10 Desktop", "060001092002ac6d90ec0132b3204cd39c7ced3e48436ba15dc6314778"},
     {"BM2", "Battery Monitor", "4c000215655f83caae16a10a702e31f30d58dd82f644000064"},
     {"BM2", "Battery Monitor", "4c000215655f83caae16a10a702e31f30d58dd82f441423144"},
     {"SmartDry", "Laundry Sensor", "ae0156d708420000c84252006907"},
@@ -392,9 +389,6 @@ const char* test_mfgdata[][3] = {
     {"Atomax", "Skale I/II", "ef81d70400ff"},
     {"Atomax", "Skale I/II", "ef81280100ff"},
     {"Atomax", "Skale I/II", "ef8160fcffff"},
-#ifdef DECODE_RANDOM_MAC_DEVICES
-    {"MS-CDP", "Windows 10 Desktop", "060001092002ac6d90ec0132b3204cd39c7ced3e48436ba15dc6314778"},
-#endif
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
@@ -438,6 +432,7 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::BM3IN1,
     TheengsDecoder::BLE_ID_NUM::BM4IN1,
     TheengsDecoder::BLE_ID_NUM::BM1IN1,
+    TheengsDecoder::BLE_ID_NUM::MS_CDP,
     TheengsDecoder::BLE_ID_NUM::BM2,
     TheengsDecoder::BLE_ID_NUM::BM2,
     TheengsDecoder::BLE_ID_NUM::SMARTDRY,
@@ -490,9 +485,6 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::SKALE,
     TheengsDecoder::BLE_ID_NUM::SKALE,
     TheengsDecoder::BLE_ID_NUM::SKALE,
-#ifdef DECODE_RANDOM_MAC_DEVICES
-    TheengsDecoder::BLE_ID_NUM::MS_CDP,
-#endif
 };
 
 // uuid test input [test name] [device name] [uuid] [manufacturer data] [service data]
@@ -582,6 +574,7 @@ const char* test_uuid[][4] = {
     {"MokoXPro", "feab", "servicedata", "70000a011201ee0caf03def14635998a"},
     {"MokoXPro", "feab", "servicedata", "60000a010007154039c0fa000bf901f40c93fe3487"},
     {"MokoXPro", "feab", "servicedata", "60000a0100070100ff403ec00bf901f40c93fe3487"},
+    {"GAEN", "fd6f", "servicedata", "e7c6d34c71e48baf278bd99be74685bca78126ab"},
     {"Switchbot_S1", "0d00", "servicedata", "48d0db"},
     {"Switchbot_S1", "0d00", "servicedata", "4890cc"},
     {"Switchbot_S1", "0d00", "servicedata", "48005b"},
@@ -646,9 +639,6 @@ const char* test_uuid[][4] = {
     {"BlueCharm BC08", "0xfeaa", "servicedata", "21010b0c0df500ff95fe69fc80"},
     {"Switchbot_Contact", "0xfd3d", "servicedata", "640064440359ffff42"},
     {"Switchbot_MotionSensor", "0xfd3d", "servicedata", "73006402f002"},
-#ifdef DECODE_RANDOM_MAC_DEVICES
-    {"GAEN", "fd6f", "servicedata", "e7c6d34c71e48baf278bd99be74685bca78126ab"},
-#endif
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
@@ -676,6 +666,7 @@ TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
     TheengsDecoder::BLE_ID_NUM::MOKOBEACONXPRO,
     TheengsDecoder::BLE_ID_NUM::MOKOBEACONXPRO,
     TheengsDecoder::BLE_ID_NUM::MOKOBEACONXPRO,
+    TheengsDecoder::BLE_ID_NUM::GAEN,
     TheengsDecoder::BLE_ID_NUM::SBS1,
     TheengsDecoder::BLE_ID_NUM::SBS1,
     TheengsDecoder::BLE_ID_NUM::SBS1,
@@ -740,9 +731,6 @@ TheengsDecoder::BLE_ID_NUM test_uuid_id_num[]{
     TheengsDecoder::BLE_ID_NUM::BC08,
     TheengsDecoder::BLE_ID_NUM::SBCS,
     TheengsDecoder::BLE_ID_NUM::SBMS,
-#ifdef DECODE_RANDOM_MAC_DEVICES
-    TheengsDecoder::BLE_ID_NUM::GAEN,
-#endif
 };
 
 // MAC manufacturer data test input [test name] [mac] [data]


### PR DESCRIPTION
Reverts theengs/decoder#299 as filtering of Random Mac will be included at run time and we are having strange behavior of this directive depending on where it is located (platformio.ini versus .h files)