### PR TITLE
Mi Band/Amazfit restriction

### DIFF
--- a/src/devices/Miband_json.h
+++ b/src/devices/Miband_json.h
@@ -1,11 +1,11 @@
-const char* _Miband_json = "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"tag\":\"0b0a\",\"condition\":[\"manufacturerdata\",\"=\",52,\"index\",0,\"5701\",\"&\",\"manufacturerdata\",\"mac@index\",40],\"conditionnomac\":[\"uuid\",\"contain\",\"fee0\"],\"properties\":{\"steps\":{\"condition\":[\"servicedata\",\"=\",8],\"decoder\":[\"value_from_hex_data\",\"servicedata\",0,4,true,false]},\"act_bpm\":{\"condition\":[\"manufacturerdata\",10,\"!\",\"f\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,false]},\"device\":{\"decoder\":[\"static_value\",\"Xiaomi/Amazfit Tracker\"]}}}";
+const char* _Miband_json = "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"tag\":\"0b0a\",\"condition\":[\"manufacturerdata\",\"=\",52,\"index\",0,\"570102\",\"&\",\"manufacturerdata\",\"mac@index\",40],\"conditionnomac\":[\"uuid\",\"contain\",\"fee0\"],\"properties\":{\"steps\":{\"condition\":[\"servicedata\",\"=\",8],\"decoder\":[\"value_from_hex_data\",\"servicedata\",0,4,true,false]},\"act_bpm\":{\"condition\":[\"manufacturerdata\",10,\"!\",\"f\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,false]},\"device\":{\"decoder\":[\"static_value\",\"Xiaomi/Amazfit Tracker\"]}}}";
 /*R""""(
 {
    "brand":"Xiaomi/Amazfit",
    "model":"Mi Band/Smart Watch",
    "model_id":"MB/SW",
    "tag":"0b0a",
-   "condition":["manufacturerdata", "=", 52, "index", 0, "5701", "&", "manufacturerdata", "mac@index", 40],
+   "condition":["manufacturerdata", "=", 52, "index", 0, "570102", "&", "manufacturerdata", "mac@index", 40],
    "conditionnomac":["uuid", "contain", "fee0"],
    "properties":{
       "steps":{

--- a/src/devices/Miband_json.h
+++ b/src/devices/Miband_json.h
@@ -1,11 +1,11 @@
-const char* _Miband_json = "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"tag\":\"0b0a\",\"condition\":[\"manufacturerdata\",\"=\",52,\"index\",0,\"570102\",\"&\",\"manufacturerdata\",\"mac@index\",40],\"conditionnomac\":[\"uuid\",\"contain\",\"fee0\"],\"properties\":{\"steps\":{\"condition\":[\"servicedata\",\"=\",8],\"decoder\":[\"value_from_hex_data\",\"servicedata\",0,4,true,false]},\"act_bpm\":{\"condition\":[\"manufacturerdata\",10,\"!\",\"f\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,false]},\"device\":{\"decoder\":[\"static_value\",\"Xiaomi/Amazfit Tracker\"]}}}";
+const char* _Miband_json = "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"tag\":\"0b0a\",\"condition\":[\"manufacturerdata\",\"=\",52,\"index\",0,\"5701\",\"&\",\"manufacturerdata\",\"mac@index\",40],\"conditionnomac\":[\"uuid\",\"contain\",\"fee0\"],\"properties\":{\"steps\":{\"condition\":[\"servicedata\",\"=\",8],\"decoder\":[\"value_from_hex_data\",\"servicedata\",0,4,true,false]},\"act_bpm\":{\"condition\":[\"manufacturerdata\",0,\"570102\",\"&\",\"manufacturerdata\",10,\"!\",\"f\"],\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,false]},\"device\":{\"decoder\":[\"static_value\",\"Xiaomi/Amazfit Tracker\"]}}}";
 /*R""""(
 {
    "brand":"Xiaomi/Amazfit",
    "model":"Mi Band/Smart Watch",
    "model_id":"MB/SW",
    "tag":"0b0a",
-   "condition":["manufacturerdata", "=", 52, "index", 0, "570102", "&", "manufacturerdata", "mac@index", 40],
+   "condition":["manufacturerdata", "=", 52, "index", 0, "5701", "&", "manufacturerdata", "mac@index", 40],
    "conditionnomac":["uuid", "contain", "fee0"],
    "properties":{
       "steps":{
@@ -13,7 +13,7 @@ const char* _Miband_json = "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Sm
          "decoder":["value_from_hex_data", "servicedata", 0, 4, true, false]
       },
       "act_bpm":{
-         "condition":["manufacturerdata", 10, "!", "f"],
+         "condition":["manufacturerdata", 0, "570102", "&", "manufacturerdata", 10, "!", "f"],
          "decoder":["value_from_hex_data", "manufacturerdata", 10, 2, false, false]
       },
       "device":{

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -813,8 +813,8 @@ TheengsDecoder::BLE_ID_NUM test_mac_mfgdata_id_num[]{
 const char* test_mac_mfgsvcdata[][4] = {
     {"MiBand", "AA:BB:CC:DD:EE:FF", "57010202017dffffffffffffffffffffffffff02aabbccddeeff", "8d230000"},
     {"MiBand", "AA:BB:CC:DD:EE:FF", "570102020184ffffffffffffffffffffffffff02aabbccddeeff", ""},
-    {"MiBand", "AA:BB:CC:DD:EE:FF", "5701020201ffffffffffffffffffffffffffff02aabbccddeeff", "ac1e0000"},
-    {"MiBand", "AA:BB:CC:DD:EE:FF", "57010202ffffffffffffffffffffffffffffff02aabbccddeeff", ""},
+    {"MiBand", "AA:BB:CC:DD:EE:FF", "570102ffffffffffffffffffffffffffffffff02aabbccddeeff", "ac1e0000"},
+    {"MiBand", "AA:BB:CC:DD:EE:FF", "570102ffffffffffffffffffffffffffffffff02aabbccddeeff", ""},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mac_mfgsvcdata_id_num[]{

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -273,6 +273,7 @@ const char* expected_mac_mfgsvcdata[] = {
     "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"type\":\"BODY\",\"acts\":true,\"track\":true,\"act_bpm\":132,\"device\":\"Xiaomi/Amazfit Tracker\"}",
     "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"type\":\"BODY\",\"acts\":true,\"track\":true,\"steps\":7852,\"device\":\"Xiaomi/Amazfit Tracker\"}",
     "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"type\":\"BODY\",\"acts\":true,\"track\":true,\"device\":\"Xiaomi/Amazfit Tracker\"}",
+    "{\"brand\":\"Xiaomi/Amazfit\",\"model\":\"Mi Band/Smart Watch\",\"model_id\":\"MB/SW\",\"type\":\"BODY\",\"acts\":true,\"track\":true,\"steps\":7852,\"device\":\"Xiaomi/Amazfit Tracker\"}",
 };
 
 // Service data test input [test name] [data]
@@ -815,9 +816,11 @@ const char* test_mac_mfgsvcdata[][4] = {
     {"MiBand", "AA:BB:CC:DD:EE:FF", "570102020184ffffffffffffffffffffffffff02aabbccddeeff", ""},
     {"MiBand", "AA:BB:CC:DD:EE:FF", "570102ffffffffffffffffffffffffffffffff02aabbccddeeff", "ac1e0000"},
     {"MiBand", "AA:BB:CC:DD:EE:FF", "570102ffffffffffffffffffffffffffffffff02aabbccddeeff", ""},
+    {"Amazfit Bip S", "AA:BB:CC:DD:EE:FF", "570100dcdde701d61acdc010c59c77fad0bf8e02aabbccddeeff", "ac1e0000"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mac_mfgsvcdata_id_num[]{
+    TheengsDecoder::BLE_ID_NUM::MIBAND,
     TheengsDecoder::BLE_ID_NUM::MIBAND,
     TheengsDecoder::BLE_ID_NUM::MIBAND,
     TheengsDecoder::BLE_ID_NUM::MIBAND,


### PR DESCRIPTION
Mi Band/Amazfit decoder restriction to not catch wrongly decoded devices like the Amazfit Bip S and similar.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
