### PR TITLE
Replace deprecated BLEDevice.rssi by AdvertisementData.rssi

### DIFF
--- a/examples/python/ScanAndDecode.py
+++ b/examples/python/ScanAndDecode.py
@@ -6,7 +6,7 @@ from TheengsDecoder import decodeBLE as dble
 from TheengsDecoder import getProperties, getAttribute
 
 def detection_callback(device, advertisement_data):
-    print(device.address, "RSSI:", device.rssi, advertisement_data)
+    print(f"{device.address}:{advertisement_data}")
     data_json = {}
 
     if advertisement_data.service_data:
@@ -26,7 +26,7 @@ def detection_callback(device, advertisement_data):
 
     if data_json:
         data_json["id"] = device.address
-        data_json["rssi"] = device.rssi
+        data_json["rssi"] = advertisement_data.rssi
         print("data sent to decoder: ", json.dumps(data_json))
         data_json = dble(json.dumps(data_json))
         print("TheengsDecoder found device:", data_json)


### PR DESCRIPTION
## Description:

Bleak 0.20.0 deprecates `BLEDevice.rssi`. This PR replaces this attribute in the Python example by `AdvertisementData.rssi`, introduced in Bleak 0.19.0.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
