### PR TITLE
Don't remove servicedata, tags and so on in Python _decoder.cpp

### DIFF
--- a/python/TheengsDecoder/_decoder.cpp
+++ b/python/TheengsDecoder/_decoder.cpp
@@ -23,14 +23,6 @@ static PyObject *decode_BLE(PyObject *self, PyObject *args)
 
     if (decoder.decodeBLEJson(bleObject) >= 0) {
       std::string buf;
-      bleObject.remove("servicedata");
-      bleObject.remove("manufacturerdata");
-      bleObject.remove("servicedatauuid");
-      bleObject.remove("type");
-      bleObject.remove("cidc");
-      bleObject.remove("acts");
-      bleObject.remove("cont");
-      bleObject.remove("track");
       serializeJson(bleObject, buf);
       return Py_BuildValue("s", buf.c_str());
     }


### PR DESCRIPTION
## Description:

Don't remove servicedata, tags and so on in the `decode_BLE` function of the Python decoder's `_decoder.cpp`. This shifts the responsibility to remove unneeded information to the user of the library, such as Theengs Gateway.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
