### PR TITLE
Decoder for ShellyBLU Button1

### DIFF
--- a/docs/devices/SBBT-002C.md
+++ b/docs/devices/SBBT-002C.md
@@ -1,0 +1,19 @@
+# ShellyBLU Button1
+
+|Model Id|[SBBT-002C](https://github.com/theengs/decoder/blob/development/src/devices/SBBT_002C_json.h)|
+|-|-|
+|Brand|Shelly|
+|Model|ShellyBLU Button1|
+|Short Description|Button|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|CR2032|
+|Exchanged data|button press type, battery, packet ID|
+|Encrypted|No|
+
+The button press type is encoded as:
+
+* 1 - Press
+* 2 - Double press
+* 3 - Triple press
+* 4 - Long press

--- a/docs/devices/SBOT.md
+++ b/docs/devices/SBOT.md
@@ -1,6 +1,6 @@
 # SwitchBot Outdoor Meter
 
-|Model Id|[W340001X)](https://github.com/theengs/decoder/blob/development/src/devices/SBOT_json.h)|
+|Model Id|[W340001X](https://github.com/theengs/decoder/blob/development/src/devices/SBOT_json.h)|
 |-|-|
 |Brand|SwitchBot|
 |Model|Outdoor Meter|

--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -52,12 +52,12 @@ Each device should also have an encoded **tag** property to, at the minimum, def
     </thead>
     <tbody>
         <tr>
-            <td rowspan=20>Byte[0]</td>
-            <td rowspan=20>Device Type > "type":</td>
+            <td rowspan=21>Byte[0]</td>
+            <td rowspan=21>Device Type > "type":</td>
             <td rowspan=1>0 - Reserved</td>
         </tr>
         <tr>
-            <td rowspan=1>1 - THB - temperature, humidity, battery<</td>
+            <td rowspan=1>1 - THB - temperature, humidity, battery</td>
         </tr>
         <tr>
             <td rowspan=1>2 - THBX - temperature, humidity, battery, extras</td>
@@ -105,7 +105,10 @@ Each device should also have an encoded **tag** property to, at the minimum, def
             <td rowspan=1>16 - TRACK - bluetooth tracker</td>
         </tr>
         <tr>
-            <td rowspan=1>17-253 - Reserved</td>
+            <td rowspan=1>17 - BTN - button</td>
+        </tr>
+        <tr>
+            <td rowspan=1>18-253 - Reserved</td>
         </tr>
         <tr>
             <td rowspan=1>254 - RMAC - known random MAC address devices</td>

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -564,6 +564,9 @@ int TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
           case 16:
             doc["type"] = "TRACK"; // Bluetooth tracker
             break;
+          case 17:
+            doc["type"] = "BTN"; // Button
+            break;
           case 254:
             doc["type"] = "RMAC"; // random MAC address devices
             break;

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -125,6 +125,7 @@ public:
     APPLE_CONT,
     APPLE_CONTAT,
     SERVICE_DATA,
+    SBBT_002C,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -86,6 +86,7 @@
 #include "devices/iBeacon_json.h"
 #include "devices/APPLE_json.h"
 #include "devices/ServiceData_json.h"
+#include "devices/SBBT_002C_json.h"
 
 
 const char* _devices[][2] = {
@@ -168,4 +169,5 @@ const char* _devices[][2] = {
     {_APPLE_json, _APPLE_json_props},
     {_APPLE_json_at, _APPLE_json_props},
     {_ServiceData_json, _ServiceData_json_props},
+    {_SBBT_002C_json, _SBBT_002C_json_props},
 };

--- a/src/devices/SBBT_002C_json.h
+++ b/src/devices/SBBT_002C_json.h
@@ -1,0 +1,42 @@
+const char* _SBBT_002C_json = "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"tag\":\"1104\",\"condition\":[\"uuid\",\"index\",0,\"fcd2\",\"&\",\"servicedata\",\"=\",14,\"index\",0,\"40\",\"&\",\"name\",\"index\",0,\"SBBT-002C\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]},\"press\":{\"condition\":[\"servicedata\",10,\"3a\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,2,false,false]}}}";
+/*R""""(
+{
+   "brand":"Shelly",
+   "model":"ShellyBLU Button1",
+   "model_id":"SBBT-002C",
+   "tag":"1104",
+   "condition":["uuid", "index", 0, "fcd2", "&", "servicedata", "=", 14, "index", 0, "40", "&", "name", "index", 0, "SBBT-002C"],
+   "properties":{
+      "packet":{
+         "condition":["servicedata", 2, "00"],
+         "decoder":["value_from_hex_data", "servicedata", 4, 2, false, false]
+      },
+      "batt":{
+         "condition":["servicedata", 6, "01"],
+         "decoder":["value_from_hex_data", "servicedata", 8, 2, false, false]
+      },
+      "press":{
+         "condition":["servicedata", 10, "3a"],
+         "decoder":["value_from_hex_data", "servicedata", 12, 2, false, false]
+      }
+   }
+})"""";*/
+
+const char* _SBBT_002C_json_props = "{\"properties\":{\"packet\":{\"unit\":\"int\",\"name\":\"packet id\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"press\":{\"unit\":\"int\",\"name\":\"press type\"}}}";
+/*R""""(
+{
+   "properties":{
+      "packet":{
+         "unit":"int",
+         "name":"packet id"
+      },
+      "batt":{
+         "unit":"%",
+         "name":"battery"
+      },
+      "press":{
+         "unit":"int",
+         "name":"press type"
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -158,6 +158,10 @@ const char* expected_uuid_name_svcdata[] = {
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX\",\"type\":\"THB\",\"tempc\":19.23,\"tempf\":66.614,\"hum\":48.36,\"batt\":100,\"volt\":2.959}",
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX\",\"type\":\"THB\",\"tempc\":-6.7,\"tempf\":19.94,\"hum\":50.53,\"batt\":100,\"volt\":3.143}",
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX\",\"type\":\"THB\",\"tempc\":24.28,\"tempf\":75.704,\"hum\":43.65,\"batt\":100,\"volt\":3.125}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"cont\":true,\"packet\":29,\"batt\":100,\"press\":1}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"cont\":true,\"packet\":30,\"batt\":100,\"press\":2}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"cont\":true,\"packet\":31,\"batt\":100,\"press\":3}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"cont\":true,\"packet\":32,\"batt\":100,\"press\":4}",
 };
 
 const char* expected_uuid[] = {
@@ -578,6 +582,10 @@ const char* test_uuid_name_svcdata[][4] = {
     {"LYWSD03MMC_PVVX", "0x181a", "MHO_SAL", "628f5238c1a48307e4128f0b64b40f"},
     {"LYWSD03MMC_PVVX", "0x181a", "MHO_SAL", "5601cf38c1a462fdbd13470c64cc0f"},
     {"MJWSD05MMC_PVVX", "0x181a", "BTH_F6C51E", "2fdedf38c1a47c090d11350c644b05"},
+    {"SBBT-002C press", "0xfcd2", "SBBT-002C", "40001d01643a01"},
+    {"SBBT-002C double press", "0xfcd2", "SBBT-002C", "40001e01643a02"},
+    {"SBBT-002C triple press", "0xfcd2", "SBBT-002C", "40001f01643a03"},
+    {"SBBT-002C long press", "0xfcd2", "SBBT-002C", "40002001643a04"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{
@@ -601,6 +609,10 @@ TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::LYWSD03MMC_PVVX,
     TheengsDecoder::BLE_ID_NUM::LYWSD03MMC_PVVX,
     TheengsDecoder::BLE_ID_NUM::LYWSD03MMC_PVVX,
+    TheengsDecoder::BLE_ID_NUM::SBBT_002C,
+    TheengsDecoder::BLE_ID_NUM::SBBT_002C,
+    TheengsDecoder::BLE_ID_NUM::SBBT_002C,
+    TheengsDecoder::BLE_ID_NUM::SBBT_002C,
 };
 
 // uuid test input [test name] [uuid] [data source] [data]


### PR DESCRIPTION
## Description:

Adds a decoder for button presses for the [ShellyBLU Button1](https://kb.shelly.cloud/knowledge-base/shellyblu-button1) using the unencrypted [BTHome](https://bthome.io/format/) format.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
