### PR TITLE
Fix MS-CDP decoder and add new device types

### DIFF
--- a/src/devices/MS_CDP_json.h
+++ b/src/devices/MS_CDP_json.h
@@ -1,4 +1,4 @@
-const char* _MS_CDP_json = "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"tag\":\"fe\",\"condition\":[\"manufacturerdata\",\"index\",0,\"060001\"],\"properties\":{\"device\":{\"condition\":[\"manufacturerdata\",7,\"1\"],\"decoder\":[\"static_value\",\"Xbox One\"]},\"_device\":{\"condition\":[\"manufacturerdata\",7,\"6\"],\"decoder\":[\"static_value\",\"Apple iPhone\"]},\"__device\":{\"condition\":[\"manufacturerdata\",7,\"7\"],\"decoder\":[\"static_value\",\"Apple iPad\"]},\"___device\":{\"condition\":[\"manufacturerdata\",7,\"8\"],\"decoder\":[\"static_value\",\"Android device\"]},\"____device\":{\"condition\":[\"manufacturerdata\",7,\"9\"],\"decoder\":[\"static_value\",\"Windows 10 Desktop\"]},\"_____device\":{\"condition\":[\"manufacturerdata\",7,\"11\"],\"decoder\":[\"static_value\",\"Windows 10 Phone\"]},\"______device\":{\"condition\":[\"manufacturerdata\",7,\"12\"],\"decoder\":[\"static_value\",\"Linux device\"]},\"_______device\":{\"condition\":[\"manufacturerdata\",7,\"17\"],\"decoder\":[\"static_value\",\"Windows IoT\"]},\"________device\":{\"condition\":[\"manufacturerdata\",7,\"14\"],\"decoder\":[\"static_value\",\"Surface Hub\"]},\"salt\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",12,8]},\"hash\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",20,32]}}}}";
+const char* _MS_CDP_json = "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"tag\":\"fe\",\"condition\":[\"manufacturerdata\",\"index\",0,\"060001\"],\"properties\":{\"device\":{\"condition\":[\"manufacturerdata\",7,\"1\"],\"decoder\":[\"static_value\",\"Xbox One\"]},\"_device\":{\"condition\":[\"manufacturerdata\",7,\"6\"],\"decoder\":[\"static_value\",\"Apple iPhone\"]},\"__device\":{\"condition\":[\"manufacturerdata\",7,\"7\"],\"decoder\":[\"static_value\",\"Apple iPad\"]},\"___device\":{\"condition\":[\"manufacturerdata\",7,\"8\"],\"decoder\":[\"static_value\",\"Android device\"]},\"____device\":{\"condition\":[\"manufacturerdata\",7,\"9\"],\"decoder\":[\"static_value\",\"Windows 10 Desktop\"]},\"_____device\":{\"condition\":[\"manufacturerdata\",7,\"11\"],\"decoder\":[\"static_value\",\"Windows 10 Phone\"]},\"______device\":{\"condition\":[\"manufacturerdata\",7,\"12\"],\"decoder\":[\"static_value\",\"Linux device\"]},\"_______device\":{\"condition\":[\"manufacturerdata\",7,\"13\"],\"decoder\":[\"static_value\",\"Windows IoT\"]},\"________device\":{\"condition\":[\"manufacturerdata\",7,\"14\"],\"decoder\":[\"static_value\",\"Surface Hub\"]},\"_________device\":{\"condition\":[\"manufacturerdata\",7,\"15\"],\"decoder\":[\"static_value\",\"Windows laptop\"]},\"__________device\":{\"condition\":[\"manufacturerdata\",7,\"16\"],\"decoder\":[\"static_value\",\"Windows tablet\"]},\"salt\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",12,8]},\"hash\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",20,32]}}}";
 /*R""""(
 {
    "brand":"GENERIC",
@@ -42,6 +42,14 @@ const char* _MS_CDP_json = "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_
       "________device":{
          "condition":["manufacturerdata", 7, "14"],
          "decoder":["static_value", "Surface Hub"]
+      },
+      "_________device":{
+         "condition":["manufacturerdata", 7, "15"],
+         "decoder":["static_value", "Windows laptop"]
+      },
+      "__________device":{
+         "condition":["manufacturerdata", 7, "16"],
+         "decoder":["static_value", "Windows tablet"]
       },
       "salt":{
          "decoder":["string_from_hex_data", "manufacturerdata", 12, 8]


### PR DESCRIPTION
## Description:

* Fixes an issue found by Nate Eaton's `decoder_prep.py` in MS-CDP decoder
* Adds two new device types from the latest [MS-CDP specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cdp/77b446d0-8cea-4821-ad21-fabdf4d9a569)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
