### PR TITLE
SBBT-002C: document periodic beacon

### DIFF
--- a/docs/devices/SBBT-002C.md
+++ b/docs/devices/SBBT-002C.md
@@ -13,6 +13,7 @@
 
 The button press type is encoded as:
 
+* 0 - None (sent every 8 seconds if beacon mode is enabled)
 * 1 - Press
 * 2 - Double press
 * 3 - Triple press


### PR DESCRIPTION
## Description:

Documents the ShellyBLU Button1's beacon mode.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
