### PR TITLE
Fix SBBT-002C decoder to detect new firmware

### DIFF
--- a/src/devices/SBBT_002C_json.h
+++ b/src/devices/SBBT_002C_json.h
@@ -1,11 +1,11 @@
-const char* _SBBT_002C_json = "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"tag\":\"1104\",\"condition\":[\"uuid\",\"index\",0,\"fcd2\",\"&\",\"servicedata\",\"=\",14,\"index\",0,\"40\",\"&\",\"name\",\"index\",0,\"SBBT-002C\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]},\"press\":{\"condition\":[\"servicedata\",10,\"3a\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,2,false,false]}}}";
+const char* _SBBT_002C_json = "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"tag\":\"1106\",\"condition\":[\"servicedata\",\"=\",14,\"index\",0,\"40\",\"|\",\"servicedata\",\"=\",14,\"index\",0,\"44\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"SBBT-002C\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]},\"press\":{\"condition\":[\"servicedata\",10,\"3a\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,2,false,false]}}}";
 /*R""""(
 {
    "brand":"Shelly",
    "model":"ShellyBLU Button1",
    "model_id":"SBBT-002C",
-   "tag":"1104",
-   "condition":["uuid", "index", 0, "fcd2", "&", "servicedata", "=", 14, "index", 0, "40", "&", "name", "index", 0, "SBBT-002C"],
+   "tag":"1106",
+   "condition":["servicedata", "=", 14, "index", 0, "40", "|", "servicedata", "=", 14, "index", 0, "44", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "SBBT-002C"],
    "properties":{
       "packet":{
          "condition":["servicedata", 2, "00"],

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -158,10 +158,11 @@ const char* expected_uuid_name_svcdata[] = {
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX\",\"type\":\"THB\",\"tempc\":19.23,\"tempf\":66.614,\"hum\":48.36,\"batt\":100,\"volt\":2.959}",
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX\",\"type\":\"THB\",\"tempc\":-6.7,\"tempf\":19.94,\"hum\":50.53,\"batt\":100,\"volt\":3.143}",
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX\",\"type\":\"THB\",\"tempc\":24.28,\"tempf\":75.704,\"hum\":43.65,\"batt\":100,\"volt\":3.125}",
-    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"cont\":true,\"packet\":29,\"batt\":100,\"press\":1}",
-    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"cont\":true,\"packet\":30,\"batt\":100,\"press\":2}",
-    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"cont\":true,\"packet\":31,\"batt\":100,\"press\":3}",
-    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"cont\":true,\"packet\":32,\"batt\":100,\"press\":4}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":29,\"batt\":100,\"press\":1}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":30,\"batt\":100,\"press\":2}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":31,\"batt\":100,\"press\":3}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":32,\"batt\":100,\"press\":4}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":171,\"batt\":100,\"press\":1}",
 };
 
 const char* expected_uuid[] = {
@@ -586,6 +587,7 @@ const char* test_uuid_name_svcdata[][4] = {
     {"SBBT-002C double press", "0xfcd2", "SBBT-002C", "40001e01643a02"},
     {"SBBT-002C triple press", "0xfcd2", "SBBT-002C", "40001f01643a03"},
     {"SBBT-002C long press", "0xfcd2", "SBBT-002C", "40002001643a04"},
+    {"SBBT-002C press", "0xfcd2", "SBBT-002C", "4400ab01643a01"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{
@@ -609,6 +611,7 @@ TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::LYWSD03MMC_PVVX,
     TheengsDecoder::BLE_ID_NUM::LYWSD03MMC_PVVX,
     TheengsDecoder::BLE_ID_NUM::LYWSD03MMC_PVVX,
+    TheengsDecoder::BLE_ID_NUM::SBBT_002C,
     TheengsDecoder::BLE_ID_NUM::SBBT_002C,
     TheengsDecoder::BLE_ID_NUM::SBBT_002C,
     TheengsDecoder::BLE_ID_NUM::SBBT_002C,


### PR DESCRIPTION
## Description:

Starting from firmware 20230530-112223/v1.0.7-rc1@879855cd the ShellyBLU Button1 advertises the trigger-based device flag in the [BTHome device information](https://bthome.io/format/), so advertisements start with 44 instead of 40. This PR changes the decoder to detect both prefixes.

This PR also fixes the tag, as the decoder needs active scanning to identify the device type from its name.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
