### PR TITLE
Add decoder for encrypted advertisements of ShellyBLU Button1

### DIFF
--- a/docs/devices/SBBT-002C-encrypted.md
+++ b/docs/devices/SBBT-002C-encrypted.md
@@ -1,0 +1,14 @@
+# ShellyBLU Button1
+
+|Model Id|[SBBT-002C-ENC](https://github.com/theengs/decoder/blob/development/src/devices/SBBT_002C_encrypted_json.h)|
+|-|-|
+|Brand|Shelly|
+|Model|ShellyBLU Button1 encrypted|
+|Short Description|Button|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|CR2032|
+|Exchanged data|ciphertext, counter, message integrity check|
+|Encrypted|Yes|
+
+With the right bindkey, the encrypted data can be decrypted to get the same data as the [SBBT-002C](https://github.com/theengs/decoder/blob/development/src/devices/SBBT_002C_json.h) decoder.

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -128,6 +128,7 @@ public:
     APPLE_CONTAT,
     SERVICE_DATA,
     SBBT_002C,
+    SBBT_002C_ENC,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -89,6 +89,7 @@
 #include "devices/APPLE_json.h"
 #include "devices/ServiceData_json.h"
 #include "devices/SBBT_002C_json.h"
+#include "devices/SBBT_002C_encrypted_json.h"
 
 
 const char* _devices[][2] = {
@@ -174,4 +175,5 @@ const char* _devices[][2] = {
     {_APPLE_json_at, _APPLE_json_props},
     {_ServiceData_json, _ServiceData_json_props},
     {_SBBT_002C_json, _SBBT_002C_json_props},
+    {_SBBT_002C_encrypted_json, _SBBT_002C_encrypted_json_props},
 };

--- a/src/devices/SBBT_002C_encrypted_json.h
+++ b/src/devices/SBBT_002C_encrypted_json.h
@@ -1,0 +1,47 @@
+const char* _SBBT_002C_encrypted_json = "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1 encrypted\",\"model_id\":\"SBBT-002C-ENC\",\"tag\":\"1116\",\"condition\":[\"servicedata\",\"index\",0,\"41\",\"|\",\"servicedata\",\"index\",0,\"45\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"SBBT-002C\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,12]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",14,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",22,8]},\"mac\":{\"condition\":[\"manufacturerdata\",\"=\",30],\"decoder\":[\"revmac_from_hex_data\",\"manufacturerdata\",18]}}}";
+/*R""""(
+{
+   "brand":"Shelly",
+   "model":"ShellyBLU Button1 encrypted",
+   "model_id":"SBBT-002C-ENC",
+   "tag":"1116",
+   "condition":["servicedata", "index", 0, "41", "|", "servicedata", "index", 0, "45", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "SBBT-002C"],
+   "properties":{
+      "cipher":{
+         "decoder":["string_from_hex_data", "servicedata", 2, 12]
+      },
+      "ctr":{
+         "decoder":["string_from_hex_data", "servicedata", 14, 8]
+      },
+      "mic":{
+         "decoder":["string_from_hex_data", "servicedata", 22, 8]
+      },
+      "mac":{
+         "condition":["manufacturerdata", "=", 30],
+         "decoder":["revmac_from_hex_data", "manufacturerdata", 18]
+      }
+   }
+})"""";*/
+
+const char* _SBBT_002C_encrypted_json_props = "{\"properties\":{\"cipher\":{\"unit\":\"hex\",\"name\":\"ciphertext\"},\"ctr\":{\"unit\":\"hex\",\"name\":\"counter\"},\"mic\":{\"unit\":\"hex\",\"name\":\"message integrity check\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
+/*R""""(
+{
+   "properties":{
+      "cipher":{
+         "unit":"hex",
+         "name":"ciphertext"
+      },
+      "ctr":{
+         "unit":"hex",
+         "name":"counter"
+      },
+      "mic":{
+         "unit":"hex",
+         "name":"message integrity check"
+      },
+      "mac":{
+         "unit":"string",
+         "name":"MAC address"
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -129,6 +129,7 @@ const char* expected_name_uuid_mfgsvcdata[] = {
 
 const char* expected_name_mac_uuid_mfgsvcdata[] = {
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":29,\"batt\":100,\"press\":1,\"mac\":\"BC:02:6E:AA:BB:CC\"}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1 encrypted\",\"model_id\":\"SBBT-002C-ENC\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"encr\":true,\"cipher\":\"62511158bd25\",\"ctr\":\"b8f09364\",\"mic\":\"5b573115\",\"mac\":\"BC:02:6E:AA:BB:CC\"}",
 };
 
 const char* expected_uuid_name_svcdata[] = {
@@ -157,6 +158,7 @@ const char* expected_uuid_name_svcdata[] = {
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":31,\"batt\":100,\"press\":3}",
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":32,\"batt\":100,\"press\":4}",
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":171,\"batt\":100,\"press\":1}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1 encrypted\",\"model_id\":\"SBBT-002C-ENC\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"encr\":true,\"cipher\":\"62511158bd25\",\"ctr\":\"b8f09364\",\"mic\":\"5b573115\"}",
 };
 
 const char* expected_uuid[] = {
@@ -566,10 +568,12 @@ TheengsDecoder::BLE_ID_NUM test_name_uuid_mfgsvcdata_id_num[]{
 // uuid test input [test name] [mac] [device name] [uuid] [manufacturer data] [service data]
 const char* test_name_mac_uuid_mfgsvcdata[][6] = {
     {"SBBT-002C", "BC:02:6E:AA:BB:CC", "SBBT-002C", "0xfcd2", "a90b0109000b01000accbbaa6e02bc", "40001d01643a01"},
+    {"SBBT-002C encrypted", "BC:02:6E:AA:BB:CC", "SBBT-002C", "0xfcd2", "a90b0109000b01000accbbaa6e02bc", "4562511158bd25b8f093645b573115"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_name_mac_uuid_mfgsvcdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::SBBT_002C,
+    TheengsDecoder::BLE_ID_NUM::SBBT_002C_ENC,
 };
 
 // uuid name test input [test name] [uuid] [device name] [service data]
@@ -599,6 +603,7 @@ const char* test_uuid_name_svcdata[][4] = {
     {"SBBT-002C triple press", "0xfcd2", "SBBT-002C", "40001f01643a03"},
     {"SBBT-002C long press", "0xfcd2", "SBBT-002C", "40002001643a04"},
     {"SBBT-002C press", "0xfcd2", "SBBT-002C", "4400ab01643a01"},
+    {"SBBT-002C encrypted", "0xfcd2", "SBBT-002C", "4562511158bd25b8f093645b573115"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{
@@ -627,6 +632,7 @@ TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::SBBT_002C,
     TheengsDecoder::BLE_ID_NUM::SBBT_002C,
     TheengsDecoder::BLE_ID_NUM::SBBT_002C,
+    TheengsDecoder::BLE_ID_NUM::SBBT_002C_ENC,
 };
 
 // uuid test input [test name] [uuid] [data source] [data]


### PR DESCRIPTION
## Description:

Adds a decoder for encrypted BTHome advertisements of the ShellyBLU Button1. This results in the properties `cipher` (ciphertext), `ctr` (counter) and `mic` (message integrity check) and provides the base for decrypting the data in projects like Theengs Gateway, Theengs App and OpenMQTTGateway with a supplied bindkey.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
