### PR TITLE
Add script to check JSON strings in decoders

### DIFF
--- a/.github/workflows/PR_build.yml
+++ b/.github/workflows/PR_build.yml
@@ -3,6 +3,12 @@ name: PR_Build
 on: [push, pull_request]
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0
   gcc:
     name: GCC
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0
   gcc:
     name: GCC
     runs-on: ubuntu-20.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+  - id: check-decoders
+    name: check-decoders
+    entry: python scripts/check_decoder.py
+    language: python
+    files: ^src\/devices\/.+.h$

--- a/scripts/check_decoder.py
+++ b/scripts/check_decoder.py
@@ -1,0 +1,54 @@
+import json
+import re
+import sys
+
+
+def fix_json_strings(decoder_source):
+    """Check whether declaration in decoder source file conforms to raw string.
+
+    This returns the complete decoder source code with the JSON declaration
+    replaced by the escaped version of the corresponding raw string.
+    """
+    # Find all const char* declarations followed by a raw string in a multi-line
+    # comment.
+    code_structures = re.findall(
+        r'(const char\* \w+ = )"(.*?)";\s*\/\*\s*R""""\(([\s\S]*?)\)"""";',
+        decoder_source,
+        re.DOTALL | re.MULTILINE,
+    )
+
+    for declaration, json_string, raw_string in code_structures:
+
+        # Parse the raw JSON string and convert it back to unindented string
+        json_data = json.loads(raw_string)
+        normalized_data = json.dumps(
+            json_data, separators=(",", ":"), ensure_ascii=False, indent=None
+        )
+
+        # Escape quotes
+        normalized_data = normalized_data.replace('"', '\\"')
+
+        # Replace the original JSON string by the normalized raw string
+        decoder_source = decoder_source.replace(declaration + "\"" + json_string, declaration + "\"" + normalized_data)
+
+    return decoder_source
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Please provide a filename as command-line argument.")
+        sys.exit()
+
+    filename = sys.argv[1]
+
+    with open(filename, "r") as file:
+        content = file.read()
+
+    new_decoder_source = fix_json_strings(content)
+
+    # Write the result back to the file
+    if new_decoder_source != content:
+        with open(filename, "w") as file:
+            file.write(new_decoder_source)
+        print(f"Fixing JSON string in decoder {filename}...")
+        sys.exit(1)


### PR DESCRIPTION
## Description:

Script to check and fix JSON strings in decoders.

Based on https://github.com/NateEaton/decoder/blob/development/scripts/decoder_prep.py

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
