### PR TITLE
Add decoder for ShellyBLU Door/Window

### DIFF
--- a/docs/devices/SBDW-002C.md
+++ b/docs/devices/SBDW-002C.md
@@ -1,0 +1,12 @@
+# ShellyBLU Door/Window
+
+|Model Id|[SBDW-002C](https://github.com/theengs/decoder/blob/development/src/devices/SBDW_002C_json.h)|
+|-|-|
+|Brand|Shelly|
+|Model|ShellyBLU Door/Window|
+|Short Description|Door/window contact sensor|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power source|CR2032|
+|Exchanged data|contact, rotation, battery, packet ID|
+|Encrypted|Yes/No - Optional|

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -132,6 +132,8 @@ public:
     SERVICE_DATA,
     SBBT_002C,
     SBBT_002C_ENCR,
+    SBDW_002C,
+    SBDW_002C_ENCR,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -92,6 +92,8 @@
 #include "devices/ServiceData_json.h"
 #include "devices/SBBT_002C_json.h"
 #include "devices/SBBT_002C_ENCR_json.h"
+#include "devices/SBDW_002C_json.h"
+#include "devices/SBDW_002C_ENCR_json.h"
 
 
 const char* _devices[][2] = {
@@ -181,4 +183,6 @@ const char* _devices[][2] = {
     {_ServiceData_json, _ServiceData_json_props},
     {_SBBT_002C_json, _SBBT_002C_json_props},
     {_SBBT_002C_ENCR_json, _SBBT_002C_ENCR_json_props},
+    {_SBDW_002C_json, _SBDW_002C_json_props},
+    {_SBDW_002C_ENCR_json, _SBDW_002C_ENCR_json_props},
 };

--- a/src/devices/SBDW_002C_ENCR_json.h
+++ b/src/devices/SBDW_002C_ENCR_json.h
@@ -1,0 +1,47 @@
+const char* _SBDW_002C_ENCR_json = "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Door/Window encrypted\",\"model_id\":\"SBDW_002C_ENCR\",\"tag\":\"0416\",\"condition\":[\"servicedata\",\"index\",0,\"45\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"SBDW-002C\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,26]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",28,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",36,8]},\"mac\":{\"condition\":[\"manufacturerdata\",\"=\",30],\"decoder\":[\"revmac_from_hex_data\",\"manufacturerdata\",18]}}}";
+/*R""""(
+{
+   "brand":"Shelly",
+   "model":"ShellyBLU Door/Window encrypted",
+   "model_id":"SBDW_002C_ENCR",
+   "tag":"0416",
+   "condition":["servicedata", "index", 0, "45", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "SBDW-002C"],
+   "properties":{
+      "cipher":{
+         "decoder":["string_from_hex_data", "servicedata", 2, 26]
+      },
+      "ctr":{
+         "decoder":["string_from_hex_data", "servicedata", 28, 8]
+      },
+      "mic":{
+         "decoder":["string_from_hex_data", "servicedata", 36, 8]
+      },
+      "mac":{
+         "condition":["manufacturerdata", "=", 30],
+         "decoder":["revmac_from_hex_data", "manufacturerdata", 18]
+      }
+   }
+})"""";*/
+
+const char* _SBDW_002C_ENCR_json_props = "{\"properties\":{\"cipher\":{\"unit\":\"hex\",\"name\":\"ciphertext\"},\"ctr\":{\"unit\":\"hex\",\"name\":\"counter\"},\"mic\":{\"unit\":\"hex\",\"name\":\"message integrity check\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
+/*R""""(
+{
+   "properties":{
+      "cipher":{
+         "unit":"hex",
+         "name":"ciphertext"
+      },
+      "ctr":{
+         "unit":"hex",
+         "name":"counter"
+      },
+      "mic":{
+         "unit":"hex",
+         "name":"message integrity check"
+      },
+      "mac":{
+         "unit":"string",
+         "name":"MAC address"
+      }
+   }
+})"""";*/

--- a/src/devices/SBDW_002C_json.h
+++ b/src/devices/SBDW_002C_json.h
@@ -1,0 +1,68 @@
+const char* _SBDW_002C_json = "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Door/Window\",\"model_id\":\"SBDW-002C\",\"tag\":\"0406\",\"condition\":[\"servicedata\",\"=\",28,\"index\",0,\"44\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"SBDW-002C\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]},\"lux\":{\"condition\":[\"servicedata\",10,\"05\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,6,true,false],\"post_proc\":[\"/\",100]},\"contact\":{\"condition\":[\"servicedata\",18,\"2d\"],\"decoder\":[\"bit_static_value\",\"servicedata\",21,0,\"closed\",\"open\"]},\"rot\":{\"condition\":[\"servicedata\",22,\"3f\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",24,4,true,true],\"post_proc\":[\"/\",10]},\"mac\":{\"condition\":[\"manufacturerdata\",\"=\",30],\"decoder\":[\"revmac_from_hex_data\",\"manufacturerdata\",18]}}}";
+/*R""""(
+{
+   "brand":"Shelly",
+   "model":"ShellyBLU Door/Window",
+   "model_id":"SBDW-002C",
+   "tag":"0406",
+   "condition":["servicedata", "=", 28, "index", 0, "44", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "SBDW-002C"],
+   "properties":{
+      "packet":{
+         "condition":["servicedata", 2, "00"],
+         "decoder":["value_from_hex_data", "servicedata", 4, 2, false, false]
+      },
+      "batt":{
+         "condition":["servicedata", 6, "01"],
+         "decoder":["value_from_hex_data", "servicedata", 8, 2, false, false]
+      },
+      "lux":{
+         "condition":["servicedata", 10, "05"],
+         "decoder":["value_from_hex_data", "servicedata", 12, 6, true, false],
+         "post_proc":["/", 100]
+      },
+      "contact":{
+         "condition":["servicedata", 18, "2d"],
+         "decoder":["bit_static_value", "servicedata", 21, 0, "closed", "open"]
+      },
+      "rot":{
+         "condition":["servicedata", 22, "3f"],
+         "decoder":["value_from_hex_data", "servicedata", 24, 4, true, true],
+         "post_proc":["/", 10]
+      },
+      "mac":{
+         "condition":["manufacturerdata", "=", 30],
+         "decoder":["revmac_from_hex_data", "manufacturerdata", 18]
+      }
+   }
+})"""";*/
+
+const char* _SBDW_002C_json_props = "{\"properties\":{\"packet\":{\"unit\":\"int\",\"name\":\"packet id\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lux\":{\"unit\":\"lux\",\"name\":\"illuminance\"},\"contact\":{\"unit\":\"string\",\"name\":\"contact\"},\"rot\":{\"unit\":\"0\",\"name\":\"rotation\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
+/*R""""(
+{
+   "properties":{
+      "packet":{
+         "unit":"int",
+         "name":"packet id"
+      },
+      "batt":{
+         "unit":"%",
+         "name":"battery"
+      },
+      "lux":{
+         "unit":"lux",
+         "name":"illuminance"
+      },
+      "contact":{
+         "unit":"string",
+         "name":"contact"
+      },
+      "rot":{
+         "unit":"0",
+         "name":"rotation"
+      },
+      "mac":{
+         "unit":"string",
+         "name":"MAC address"
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -130,6 +130,9 @@ const char* expected_name_uuid_mfgsvcdata[] = {
 const char* expected_name_mac_uuid_mfgsvcdata[] = {
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1\",\"model_id\":\"SBBT-002C\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"packet\":29,\"batt\":100,\"press\":1,\"mac\":\"BC:02:6E:AA:BB:CC\"}",
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Button1 encrypted\",\"model_id\":\"SBBT_002C_ENCR\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"encr\":true,\"cipher\":\"62511158bd25\",\"ctr\":\"b8f09364\",\"mic\":\"5b573115\",\"mac\":\"BC:02:6E:AA:BB:CC\"}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Door/Window\",\"model_id\":\"SBDW-002C\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"packet\":93,\"batt\":100,\"lux\":87,\"contact\":\"open\",\"rot\":40.6,\"mac\":\"3C:2E:F5:AA:BB:CC\"}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Door/Window\",\"model_id\":\"SBDW-002C\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"packet\":86,\"batt\":100,\"lux\":673,\"contact\":\"closed\",\"rot\":0,\"mac\":\"3C:2E:F5:AA:BB:CC\"}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Door/Window encrypted\",\"model_id\":\"SBDW_002C_ENCR\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"encr\":true,\"cipher\":\"38efaf00d122b4979064e971a7\",\"ctr\":\"ed16c164\",\"mic\":\"4dc481fd\",\"mac\":\"3C:2E:F5:AA:BB:CC\"}",
 };
 
 const char* expected_uuid_name_svcdata[] = {
@@ -572,11 +575,17 @@ TheengsDecoder::BLE_ID_NUM test_name_uuid_mfgsvcdata_id_num[]{
 const char* test_name_mac_uuid_mfgsvcdata[][6] = {
     {"SBBT-002C", "BC:02:6E:AA:BB:CC", "SBBT-002C", "0xfcd2", "a90b0109000b01000accbbaa6e02bc", "40001d01643a01"},
     {"SBBT-002C encrypted", "BC:02:6E:AA:BB:CC", "SBBT-002C", "0xfcd2", "a90b0109000b01000accbbaa6e02bc", "4562511158bd25b8f093645b573115"},
+    {"SBDW-002C", "3C:2E:F5:AA:BB:CC", "SBDW-002C", "0xfcd2", "a90b0101000b02000accbbaaf52e3c", "44005d016405fc21002d013f9601"},
+    {"SBDW-002C", "3C:2E:F5:AA:BB:CC", "SBDW-002C", "0xfcd2", "a90b0101000b02000accbbaaf52e3c", "440056016405e406012d003f0000"},
+    {"SBDW-002C encrypted", "3C:2E:F5:AA:BB:CC", "SBDW-002C", "0xfcd2", "a90b0101000b02000accbbaaf52e3c", "4538efaf00d122b4979064e971a7ed16c1644dc481fd"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_name_mac_uuid_mfgsvcdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::SBBT_002C,
     TheengsDecoder::BLE_ID_NUM::SBBT_002C_ENCR,
+    TheengsDecoder::BLE_ID_NUM::SBDW_002C,
+    TheengsDecoder::BLE_ID_NUM::SBDW_002C,
+    TheengsDecoder::BLE_ID_NUM::SBDW_002C_ENCR,
 };
 
 // uuid name test input [test name] [uuid] [device name] [service data]


### PR DESCRIPTION
## Description:

Adds decoder for unencrypted and encrypted advertisements of the ShellyBLU Door/Window sensor.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
