### PR TITLE
[CI] Point gh-action-pypi-publish to python/dist directory

### DIFF
--- a/.github/workflows/manual_test-pypi.yml
+++ b/.github/workflows/manual_test-pypi.yml
@@ -1,8 +1,6 @@
 name: Publish to TestPyPI
 on:
   workflow_dispatch:
-permissions:
-  id-token: write
 jobs:
   build-n-publish:
     name: Build and publish distribution to TestPyPI
@@ -28,3 +26,4 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
+        packages-dir: python/dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   release:
     types: [published]
-permissions:
-  id-token: write
 jobs:
   build-n-publish:
     name: Build and publish distributions to PyPI
@@ -27,3 +25,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
+        packages-dir: python/dist/


### PR DESCRIPTION
## Description:

Points the gh-action-pypi-publish GitHub action to publish packages to the correct `python/dist` directory.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
