### PR TITLE
Separation of _common_BTH_props and _common_BTHM_props

### DIFF
--- a/src/devices/CGD1_json.h
+++ b/src/devices/CGD1_json.h
@@ -28,4 +28,4 @@ const char* _CGD1_json = "{\"brand\":\"ClearGrass/Qingping\",\"model\":\"Alarm C
    }
 })"""";*/
 
-const char* _CGD1_json_props = _common_BTH_props;
+const char* _CGD1_json_props = _common_BTHM_props;

--- a/src/devices/LYWSD02_json.h
+++ b/src/devices/LYWSD02_json.h
@@ -29,4 +29,4 @@ const char* _LYWSD02_json = "{\"brand\":\"Xiaomi/Mijia\",\"model\":\"e-ink Clock
    }
 })"""";*/
 
-const char* _LYWSD02_json_props = _common_BTH_props;
+const char* _LYWSD02_json_props = _common_BTHM_props;

--- a/src/devices/LYWSDCGQ_json.h
+++ b/src/devices/LYWSDCGQ_json.h
@@ -34,4 +34,4 @@ const char* _LYWSDCGQ_json = "{\"brand\":\"Xiaomi\",\"model\":\"Mi Jia round\",\
    }
 })"""";*/
 
-const char* _LYWSDCGQ_json_props = _common_BTH_props;
+const char* _LYWSDCGQ_json_props = _common_BTHM_props;

--- a/src/devices/SBOT_json.h
+++ b/src/devices/SBOT_json.h
@@ -37,4 +37,4 @@ const char* _SBOT_json = "{\"brand\":\"SwitchBot\",\"model\":\"Outdoor Meter\",\
    }
 })"""";*/
 
-const char* _SBOT_json_props = _common_BTH_props;
+const char* _SBOT_json_props = _common_BTHM_props;

--- a/src/devices/T201_json.h
+++ b/src/devices/T201_json.h
@@ -26,4 +26,4 @@ const char* _T201_json = "{\"brand\":\"Oria\",\"model\":\"TH Sensor\",\"model_id
    }
 })"""";*/
 
-const char* _T201_json_props = _common_BTH_props;
+const char* _T201_json_props = _common_BTHM_props;

--- a/src/devices/T301_json.h
+++ b/src/devices/T301_json.h
@@ -26,4 +26,4 @@ const char* _T301_json = "{\"brand\":\"Oria\",\"model\":\"TH Sensor\",\"model_id
    }
 })"""";*/
 
-const char* _T301_json_props = _common_BTH_props;
+const char* _T301_json_props = _common_BTHM_props;

--- a/src/devices/common_props.h
+++ b/src/devices/common_props.h
@@ -16,7 +16,27 @@ const char* _common_TH_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"n
    }
 })"""";*/
 
-const char* _common_BTH_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
+const char* _common_BTH_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"}}}";
+/*
+R""""(
+{
+   "properties":{
+      "tempc":{
+         "unit":"°C",
+         "name":"temperature"
+      },
+      "hum":{
+         "unit":"%",
+         "name":"humidity"
+      },
+      "batt":{
+         "unit":"%",
+         "name":"battery"
+      }
+   }
+})"""";*/
+
+const char* _common_BTHM_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
 /*
 R""""(
 {


### PR DESCRIPTION
To avoid unavailable MAC address property for BTH only devices.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
