### PR TITLE
Fix ABN07 decoder for firmware 4.0.1

### DIFF
--- a/docs/devices/ABN07.md
+++ b/docs/devices/ABN07.md
@@ -10,3 +10,5 @@
 |Power source|CR2450|
 |Exchanged data|temperature, humidity, battery, packet ID|
 |Encrypted|No|
+
+Theengs Decoder supports firmware 4.0.1 and higher on the device.

--- a/src/devices/ABN07_json.h
+++ b/src/devices/ABN07_json.h
@@ -1,4 +1,4 @@
-const char* _ABN07_json = "{\"brand\":\"April Brother\",\"model\":\"N07\",\"model_id\":\"ABN07\",\"tag\":\"0102\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"asensor_\"],\"properties\":{\"batt\":{\"condition\":[\"servicedata\",2,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",6,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",12,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,4,true,false],\"post_proc\":[\"/\",100]},\"packet\":{\"condition\":[\"servicedata\",18,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",20,2,false,false]}}}";
+const char* _ABN07_json = "{\"brand\":\"April Brother\",\"model\":\"N07\",\"model_id\":\"ABN07\",\"tag\":\"0102\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"asensor_\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",10,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",16,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false],\"post_proc\":[\"/\",100]}}}";
 /* R""""(
 {
    "brand":"April Brother",
@@ -7,31 +7,35 @@ const char* _ABN07_json = "{\"brand\":\"April Brother\",\"model\":\"N07\",\"mode
    "tag":"0102",
    "condition":["servicedata", "=", 22, "index", 0, "40", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "asensor_"],
    "properties":{
-      "batt":{
-         "condition":["servicedata", 2, "01"],
+      "packet":{
+         "condition":["servicedata", 2, "00"],
          "decoder":["value_from_hex_data", "servicedata", 4, 2, false, false]
       },
+      "batt":{
+         "condition":["servicedata", 6, "01"],
+         "decoder":["value_from_hex_data", "servicedata", 8, 2, false, false]
+      },
       "tempc":{
-         "condition":["servicedata", 6, "02"],
-         "decoder":["value_from_hex_data", "servicedata", 8, 4, true, true],
+         "condition":["servicedata", 10, "02"],
+         "decoder":["value_from_hex_data", "servicedata", 12, 4, true, true],
          "post_proc":["/", 100]
       },
       "hum":{
-         "condition":["servicedata", 12, "03"],
-         "decoder":["value_from_hex_data", "servicedata", 14, 4, true, false],
+         "condition":["servicedata", 16, "03"],
+         "decoder":["value_from_hex_data", "servicedata", 18, 4, true, false],
          "post_proc":["/", 100]
-      },
-      "packet":{
-         "condition":["servicedata", 18, "00"],
-         "decoder":["value_from_hex_data", "servicedata", 20, 2, false, false]
       }
    }
 })"""";*/
 
-const char* _ABN07_json_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"packet\":{\"unit\":\"int\",\"name\":\"packet id\"}}}";
+const char* _ABN07_json_props = "{\"properties\":{\"packet\":{\"unit\":\"int\",\"name\":\"packet id\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"}}}";
 /*R""""(
 {
    "properties":{
+      "packet":{
+         "unit":"int",
+         "name":"packet id"
+      },
       "batt":{
          "unit":"%",
          "name":"battery"
@@ -43,10 +47,6 @@ const char* _ABN07_json_props = "{\"properties\":{\"batt\":{\"unit\":\"%\",\"nam
       "hum":{
          "unit":"%",
          "name":"humidity"
-      },
-      "packet":{
-         "unit":"int",
-         "name":"packet id"
       }
    }
 })"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -621,7 +621,7 @@ const char* test_uuid_name_svcdata[][4] = {
     {"SBBT-002C encrypted", "0xfcd2", "SBBT-002C", "4562511158bd25b8f093645b573115"},
     {"LYWSD03MMC_PVVX_ENCR", "0x181a", "ATC_9C58AB", "23ef56583dd42050fe8e4d"},
     {"LYWSD03MMC_PVVX_DECR", "0x181a", "ATC_89DF88", "9c0902116404"},
-    {"ABN07", "0xfcd2", "asensor_7F7F", "4001640293090386120010"},
+    {"ABN07", "0xfcd2", "asensor_7F7F", "4000100164029309038612"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{


### PR DESCRIPTION
## Description:

The original firmware of April Brother's ABN07 had a bug so it advertised object IDs in the wrong order, which isn't compliant with the BTHome specification. After I notified April Brother about this, they fixed this behavior in firmware 4.0.1. This PR fixes Theengs Decoder to use the new format, and documents that users need to have firmware 4.0.1 or higher on their device.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
