### PR TITLE
BM2 Battery Monitor decoder generalisation

### DIFF
--- a/docs/devices/BM2.md
+++ b/docs/devices/BM2.md
@@ -1,4 +1,4 @@
-# BM2 Battery monitoring
+# BM2 Battery Monitor
 
 |Model Id|[BM2](https://github.com/theengs/decoder/blob/development/src/devices/BM2_json.h)|
 |-|-|

--- a/src/devices/BM2_json.h
+++ b/src/devices/BM2_json.h
@@ -1,12 +1,12 @@
-const char* _BM2_json = "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"tag\":\"080a\",\"condition\":[\"name\",\"index\",0,\"ZX-1689\",\"|\",\"name\",\"index\",0,\"Battery Monitor\",\"|\",\"name\",\"index\",0,\"Li Battery Monitor\",\"&\",\"manufacturerdata\",\"=\",50],\"properties\":{\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]},\"device\":{\"decoder\":[\"static_value\",\"BM2 Tracker\"]}}}";
+const char* _BM2_json = "{\"brand\":\"GENERIC\",\"model\":\"Battery Monitor\",\"model_id\":\"BM2\",\"tag\":\"0808\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c000215655f83caae16a10a702e31f30d58dd82\"],\"properties\":{\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",48,2,false]},\"device\":{\"decoder\":[\"static_value\",\"BM2 Tracker\"]}}}";
 
 /*R""""(
 {
    "brand":"GENERIC",
-   "model":"BM2 Battery Monitor",
+   "model":"Battery Monitor",
    "model_id":"BM2",
-   "tag":"080a",
-   "condition":["name", "index", 0, "ZX-1689", "|", "name", "index", 0, "Battery Monitor", "|", "name", "index", 0, "Li Battery Monitor", "&","manufacturerdata", "=", 50],
+   "tag":"0808",
+   "condition":["manufacturerdata", "=", 50, "index", 0, "4c000215655f83caae16a10a702e31f30d58dd82"],
    "properties":{
       "batt":{
          "decoder":["value_from_hex_data", "manufacturerdata", 48, 2, false]

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -52,8 +52,8 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Blue Maestro\",\"model\":\"Tempo Disc\",\"model_id\":\"TD4in1\",\"type\":\"THBX\",\"track\":true,\"tempc\":22.3,\"tempf\":72.14,\"hum\":75.9,\"pres\":1013.5,\"batt\":58}",
     "{\"brand\":\"Blue Maestro\",\"model\":\"Tempo Disc\",\"model_id\":\"TD1in1\",\"type\":\"THB\",\"track\":true,\"tempc\":25.2,\"tempf\":77.36,\"batt\":100}",
     "{\"brand\":\"GENERIC\",\"model\":\"MS-CDP\",\"model_id\":\"MS-CDP\",\"type\":\"RMAC\",\"device\":\"Microsoft advertising beacon\"}",
-    "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"acts\":true,\"track\":true,\"batt\":100,\"device\":\"BM2 Tracker\"}",
-    "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"acts\":true,\"track\":true,\"batt\":68,\"device\":\"BM2 Tracker\"}",
+    "{\"brand\":\"GENERIC\",\"model\":\"Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"track\":true,\"batt\":100,\"device\":\"BM2 Tracker\"}",
+    "{\"brand\":\"GENERIC\",\"model\":\"Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"track\":true,\"batt\":68,\"device\":\"BM2 Tracker\"}",
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"type\":\"UNIQ\",\"cidc\":false,\"tempc\":34.210289,\"tempf\":93.5785202,\"hum\":100,\"shake\":82,\"volt\":2.952,\"wake\":true}",
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"type\":\"UNIQ\",\"cidc\":false,\"tempc\":21.97295189,\"tempf\":71.5513134,\"hum\":97.91998291,\"shake\":264,\"volt\":2.951,\"wake\":true}",
     "{\"brand\":\"SmartDry\",\"model\":\"Laundry Sensor\",\"model_id\":\"SDLS\",\"type\":\"UNIQ\",\"cidc\":false,\"tempc\":31.79714203,\"tempf\":89.23485565,\"hum\":99.49163818,\"shake\":51,\"volt\":2.956,\"wake\":true}",
@@ -117,8 +117,8 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Mopeka/Lippert\",\"model\":\"Pro Check (Universal)/BottleCheck Sensor\",\"model_id\":\"M1017\",\"type\":\"UNIQ\",\"cidc\":false,\"tempc\":19,\"tempf\":66.2,\"lvl_cm\":0,\"lvl_in\":0,\"sync\":false,\"volt\":2.90625,\"batt\":100,\"quality\":0,\"accx\":16,\"accy\":-101}",
     "{\"brand\":\"Mopeka/Lippert\",\"model\":\"Pro Check (Universal)/BottleCheck Sensor\",\"model_id\":\"M1017\",\"type\":\"UNIQ\",\"cidc\":false,\"tempc\":25,\"tempf\":77,\"lvl_cm\":0,\"lvl_in\":0,\"sync\":false,\"volt\":3,\"batt\":100,\"quality\":0,\"accx\":44,\"accy\":-128}",
     "{\"brand\":\"Mopeka/Lippert\",\"model\":\"Pro Check (Universal)/BottleCheck Sensor\",\"model_id\":\"M1017\",\"type\":\"UNIQ\",\"cidc\":false,\"tempc\":21,\"tempf\":69.8,\"lvl_cm\":86.60031125,\"lvl_in\":34.09461073,\"sync\":false,\"volt\":3,\"batt\":100,\"quality\":3,\"accx\":-18,\"accy\":31}",
-    "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"acts\":true,\"track\":true,\"batt\":87,\"device\":\"BM2 Tracker\"}",
-    "{\"brand\":\"GENERIC\",\"model\":\"BM2 Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"acts\":true,\"track\":true,\"batt\":73,\"device\":\"BM2 Tracker\"}",
+    "{\"brand\":\"GENERIC\",\"model\":\"Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"track\":true,\"batt\":87,\"device\":\"BM2 Tracker\"}",
+    "{\"brand\":\"GENERIC\",\"model\":\"Battery Monitor\",\"model_id\":\"BM2\",\"type\":\"BATT\",\"track\":true,\"batt\":73,\"device\":\"BM2 Tracker\"}",
     "{\"brand\":\"Govee\",\"model\":\"Smart Thermo Hygrometer\",\"model_id\":\"H5100/01/02/04/74/77\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":26,\"tempf\":78.8,\"hum\":51,\"batt\":100}",
 };
 


### PR DESCRIPTION
BM2 Battery Monitor decoder to use manufacturerdata/iBeacon data part as model condition instead of broadcast name.

Allowing for passive scanning and avoiding iBeacon recognition.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
