### PR TITLE
Add decoder for ShellyBLU Motion

### DIFF
--- a/docs/devices/SBMO-003Z.md
+++ b/docs/devices/SBMO-003Z.md
@@ -1,0 +1,12 @@
+# ShellyBLU Motion
+
+|Model Id|[SBMO-003Z](https://github.com/theengs/decoder/blob/development/src/devices/SBMO_003Z_json.h)|
+|-|-|
+|Brand|Shelly|
+|Model|ShellyBLU Motion|
+|Short Description|Motion sensor|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power Source|CR2477|
+|Exchanged Data|motion, illuminance, battery, packet ID|
+|Encrypted|Yes/No - Optional|

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -134,6 +134,8 @@ public:
     SBBT_002C_ENCR,
     SBDW_002C,
     SBDW_002C_ENCR,
+    SBMO_003Z,
+    SBMO_003Z_ENCR,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -94,6 +94,8 @@
 #include "devices/SBBT_002C_ENCR_json.h"
 #include "devices/SBDW_002C_json.h"
 #include "devices/SBDW_002C_ENCR_json.h"
+#include "devices/SBMO_003Z_json.h"
+#include "devices/SBMO_003Z_ENCR_json.h"
 
 
 const char* _devices[][2] = {
@@ -185,4 +187,6 @@ const char* _devices[][2] = {
     {_SBBT_002C_ENCR_json, _SBBT_002C_ENCR_json_props},
     {_SBDW_002C_json, _SBDW_002C_json_props},
     {_SBDW_002C_ENCR_json, _SBDW_002C_ENCR_json_props},
+    {_SBMO_003Z_json, _SBMO_003Z_json_props},
+    {_SBMO_003Z_ENCR_json, _SBMO_003Z_ENCR_json_props},
 };

--- a/src/devices/SBMO_003Z_ENCR_json.h
+++ b/src/devices/SBMO_003Z_ENCR_json.h
@@ -1,0 +1,47 @@
+const char* _SBMO_003Z_ENCR_json = "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Motion encrypted\",\"model_id\":\"SBMO_003Z_ENCR\",\"tag\":\"0416\",\"condition\":[\"servicedata\",\"index\",0,\"45\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"SBMO-003Z\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,20]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",22,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",30,8]},\"mac\":{\"condition\":[\"manufacturerdata\",\"=\",30],\"decoder\":[\"revmac_from_hex_data\",\"manufacturerdata\",18]}}}";
+/*R""""(
+{
+   "brand":"Shelly",
+   "model":"ShellyBLU Motion encrypted",
+   "model_id":"SBMO_003Z_ENCR",
+   "tag":"0416",
+   "condition":["servicedata", "index", 0, "45", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "SBMO-003Z"],
+   "properties":{
+      "cipher":{
+         "decoder":["string_from_hex_data", "servicedata", 2, 20]
+      },
+      "ctr":{
+         "decoder":["string_from_hex_data", "servicedata", 22, 8]
+      },
+      "mic":{
+         "decoder":["string_from_hex_data", "servicedata", 30, 8]
+      },
+      "mac":{
+         "condition":["manufacturerdata", "=", 30],
+         "decoder":["revmac_from_hex_data", "manufacturerdata", 18]
+      }
+   }
+})"""";*/
+
+const char* _SBMO_003Z_ENCR_json_props = "{\"properties\":{\"cipher\":{\"unit\":\"hex\",\"name\":\"ciphertext\"},\"ctr\":{\"unit\":\"hex\",\"name\":\"counter\"},\"mic\":{\"unit\":\"hex\",\"name\":\"message integrity check\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
+/*R""""(
+{
+   "properties":{
+      "cipher":{
+         "unit":"hex",
+         "name":"ciphertext"
+      },
+      "ctr":{
+         "unit":"hex",
+         "name":"counter"
+      },
+      "mic":{
+         "unit":"hex",
+         "name":"message integrity check"
+      },
+      "mac":{
+         "unit":"string",
+         "name":"MAC address"
+      }
+   }
+})"""";*/

--- a/src/devices/SBMO_003Z_json.h
+++ b/src/devices/SBMO_003Z_json.h
@@ -1,0 +1,59 @@
+const char* _SBMO_003Z_json = "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Motion\",\"model_id\":\"SBMO-003Z\",\"tag\":\"0406\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"44\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"SBMO-003Z\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]},\"lux\":{\"condition\":[\"servicedata\",10,\"05\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,6,true,false],\"post_proc\":[\"/\",100]},\"motion\":{\"condition\":[\"servicedata\",18,\"21\"],\"decoder\":[\"bit_static_value\",\"servicedata\",21,0,false,true]},\"mac\":{\"condition\":[\"manufacturerdata\",\"=\",30],\"decoder\":[\"revmac_from_hex_data\",\"manufacturerdata\",18]}}}";
+/*R""""(
+{
+   "brand":"Shelly",
+   "model":"ShellyBLU Motion",
+   "model_id":"SBMO-003Z",
+   "tag":"0406",
+   "condition":["servicedata", "=", 22, "index", 0, "44", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "SBMO-003Z"],
+   "properties":{
+      "packet":{
+         "condition":["servicedata", 2, "00"],
+         "decoder":["value_from_hex_data", "servicedata", 4, 2, false, false]
+      },
+      "batt":{
+         "condition":["servicedata", 6, "01"],
+         "decoder":["value_from_hex_data", "servicedata", 8, 2, false, false]
+      },
+      "lux":{
+         "condition":["servicedata", 10, "05"],
+         "decoder":["value_from_hex_data", "servicedata", 12, 6, true, false],
+         "post_proc":["/", 100]
+      },
+      "motion":{
+         "condition":["servicedata", 18, "21"],
+         "decoder":["bit_static_value", "servicedata", 21, 0, false, true]
+      },
+      "mac":{
+         "condition":["manufacturerdata", "=", 30],
+         "decoder":["revmac_from_hex_data", "manufacturerdata", 18]
+      }
+   }
+})"""";*/
+
+const char* _SBMO_003Z_json_props = "{\"properties\":{\"packet\":{\"unit\":\"int\",\"name\":\"packet id\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lux\":{\"unit\":\"lux\",\"name\":\"illuminance\"},\"motion\":{\"unit\":\"status\",\"name\":\"motion\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
+/*R""""(
+{
+   "properties":{
+      "packet":{
+         "unit":"int",
+         "name":"packet id"
+      },
+      "batt":{
+         "unit":"%",
+         "name":"battery"
+      },
+      "lux":{
+         "unit":"lux",
+         "name":"illuminance"
+      },
+      "motion":{
+         "unit":"status",
+         "name":"motion"
+      },
+      "mac":{
+         "unit":"string",
+         "name":"MAC address"
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -138,6 +138,9 @@ const char* expected_name_mac_uuid_mfgsvcdata[] = {
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Door/Window\",\"model_id\":\"SBDW-002C\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"packet\":93,\"batt\":100,\"lux\":87,\"contact\":\"open\",\"rot\":40.6,\"mac\":\"3C:2E:F5:AA:BB:CC\"}",
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Door/Window\",\"model_id\":\"SBDW-002C\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"packet\":86,\"batt\":100,\"lux\":673,\"contact\":\"closed\",\"rot\":0,\"mac\":\"3C:2E:F5:AA:BB:CC\"}",
     "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Door/Window encrypted\",\"model_id\":\"SBDW_002C_ENCR\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"encr\":true,\"cipher\":\"38efaf00d122b4979064e971a7\",\"ctr\":\"ed16c164\",\"mic\":\"4dc481fd\",\"mac\":\"3C:2E:F5:AA:BB:CC\"}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Motion\",\"model_id\":\"SBMO-003Z\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"packet\":2,\"batt\":100,\"lux\":132,\"motion\":true,\"mac\":\"60:EF:AB:AA:BB:CC\"}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Motion\",\"model_id\":\"SBMO-003Z\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"packet\":5,\"batt\":100,\"lux\":36,\"motion\":false,\"mac\":\"60:EF:AB:AA:BB:CC\"}",
+    "{\"brand\":\"Shelly\",\"model\":\"ShellyBLU Motion encrypted\",\"model_id\":\"SBMO_003Z_ENCR\",\"type\":\"CTMO\",\"acts\":true,\"cont\":true,\"encr\":true,\"cipher\":\"cc08edf25d61cc0f42b6\",\"ctr\":\"00112233\",\"mic\":\"18cd3624\",\"mac\":\"60:EF:AB:AA:BB:CC\"}",
 };
 
 const char* expected_uuid_name_svcdata[] = {
@@ -593,6 +596,9 @@ const char* test_name_mac_uuid_mfgsvcdata[][6] = {
     {"SBDW-002C", "3C:2E:F5:AA:BB:CC", "SBDW-002C", "0xfcd2", "a90b0101000b02000accbbaaf52e3c", "44005d016405fc21002d013f9601"},
     {"SBDW-002C", "3C:2E:F5:AA:BB:CC", "SBDW-002C", "0xfcd2", "a90b0101000b02000accbbaaf52e3c", "440056016405e406012d003f0000"},
     {"SBDW-002C encrypted", "3C:2E:F5:AA:BB:CC", "SBDW-002C", "0xfcd2", "a90b0101000b02000accbbaaf52e3c", "4538efaf00d122b4979064e971a7ed16c1644dc481fd"},
+    {"SBMO-003Z", "60:EF:AB:AA:BB:CC", "SBMO-003Z", "0xfcd2", "a90b0101000b05000accbbaaabef60", "4400020164059033002101"},
+    {"SBMO-003Z", "60:EF:AB:AA:BB:CC", "SBMO-003Z", "0xfcd2", "a90b0101000b05000accbbaaabef60", "440005016405100e002100"},
+    {"SBMO-003Z encrypted", "60:EF:AB:AA:BB:CC", "SBMO-003Z", "0xfcd2", "a90b0101000b05000accbbaaabef60", "45cc08edf25d61cc0f42b60011223318cd3624"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_name_mac_uuid_mfgsvcdata_id_num[]{
@@ -601,6 +607,9 @@ TheengsDecoder::BLE_ID_NUM test_name_mac_uuid_mfgsvcdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::SBDW_002C,
     TheengsDecoder::BLE_ID_NUM::SBDW_002C,
     TheengsDecoder::BLE_ID_NUM::SBDW_002C_ENCR,
+    TheengsDecoder::BLE_ID_NUM::SBMO_003Z,
+    TheengsDecoder::BLE_ID_NUM::SBMO_003Z,
+    TheengsDecoder::BLE_ID_NUM::SBMO_003Z_ENCR,
 };
 
 // uuid name test input [test name] [uuid] [device name] [service data]


### PR DESCRIPTION
## Description:

Adds decoder for [ShellyBLU Motion](https://www.shelly.com/en/products/shop/shelly-blu-motion) motion sensor, both unencrypted and encrypted advertisements.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
