### PR TITLE
Potential RMAC tag ("prmac") introduction

### DIFF
--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -117,9 +117,12 @@ Each device should also have an encoded **tag** property to, at the minimum, def
             <td rowspan=1>255 - UNIQ - unique devices</td>
         </tr>
 		<tr>
-            <td rowspan=5>Byte[1]</td>
-            <td rowspan=5>Additional properties</td>
-            <td rowspan=1>Bits[7-4] - Reserved</td>
+            <td rowspan=6>Byte[1]</td>
+            <td rowspan=6>Additional properties</td>
+            <td rowspan=1>Bits[7-5] - Reserved</td>
+        </tr>
+        <tr>
+            <td rowspan=1>Bit[4] Potential RMAC device - if not defined with Identity MAC and IRK in Theengs Gateway > "prmac":</td>
         </tr>
         <tr>
             <td rowspan=1>Bit[3] Device compatible with presence tracking > "track":</td>

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -609,6 +609,15 @@ int TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
             doc["track"] = true;
             jsondata["track"] = doc["track"];
           }
+          
+          // bits[7-4]
+          data = getBinaryData(tagstring[2]);
+
+          if (((data >> 0) & 0x01) == 1) { // PRMAC - Potential RMAC device - if not defined with Identity MAC and IRK in Theengs Gateway
+            doc.add("prmac");
+            doc["prmac"] = true;
+            jsondata["prmac"] = doc["prmac"];
+          }
         }
 
         // Octet Byte[2] - Encryption Model


### PR DESCRIPTION
**Potential RMAC** tag ("prmac")  introduction for device decoders which are generally RMAC devices, unless they are defined with their Identity MAC and IRK in Theengs Gateway

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
