### PR TITLE
Apple devices test

### DIFF
--- a/src/decoder.h
+++ b/src/decoder.h
@@ -135,6 +135,7 @@ public:
     TILEN,
     JHT_F525,
     APPLEWATCH,
+    APPLEDEVICE,
     IBEACON,
     APPLE_CONT,
     APPLE_CONTAT,

--- a/src/devices.h
+++ b/src/devices.h
@@ -95,6 +95,7 @@
 #include "devices/BM6_json.h"
 #include "devices/JHT_F525_json.h"
 #include "devices/APPLEWATCH_json.h"
+#include "devices/APPLEDEVICE_json.h"
 #include "devices/iBeacon_json.h"
 #include "devices/APPLE_json.h"
 #include "devices/ServiceData_json.h"
@@ -200,6 +201,7 @@ const char* _devices[][2] = {
     {_tracker_json_tilename, _tracker_json_props},
     {_JHT_F525_json, _JHT_F525_json_props},
     {_APPLEWATCH_json, _APPLEWATCH_json_props},
+    {_APPLEDEVICE_json, _APPLEDEVICE_json_props},
     {_ibeacon_json, _ibeacon_json_props},
     {_APPLE_json, _APPLE_json_props},
     {_APPLE_json_at, _APPLE_json_props},

--- a/src/devices/APPLEDEVICE_json.h
+++ b/src/devices/APPLEDEVICE_json.h
@@ -1,0 +1,30 @@
+const char* _APPLEDEVICE_json = "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"tag\":\"1018\",\"condition\":[\"manufacturerdata\",\">=\",8,\"index\",0,\"4c0010\"],\"properties\":{\"state\":{\"condition\":[\"manufacturerdata\",9,\"b\"],\"decoder\":[\"static_value\",\"unlocked recent authenticated interaction\"]},\"_state\":{\"condition\":[\"manufacturerdata\",9,\"!\",\"b\"],\"decoder\":[\"static_value\",\"locked\"]}}}";
+/*R""""(
+{
+   "brand":"Apple",
+   "model":"Apple iPhone/iPad",
+   "model_id":"APPLEDEVICE",
+   "tag":"1018",
+   "condition":["manufacturerdata", ">=", 8, "index", 0, "4c0010"],
+   "properties":{
+      "state":{
+         "condition":["manufacturerdata", 9, "b"],
+         "decoder":["static_value", "unlocked recent authenticated interaction"]
+      },
+      "_state":{
+         "condition":["manufacturerdata", 9, "!", "b"],
+         "decoder":["static_value", "locked"]
+      }
+   }
+})"""";*/
+
+const char* _APPLEDEVICE_json_props = "{\"properties\":{\"state\":{\"unit\":\"string\",\"name\":\"state\"}}}";
+/*R""""(
+{
+   "properties":{
+      "state":{
+         "unit":"string",
+         "name":"state"
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -137,6 +137,12 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Apple\",\"model\":\"Apple Watch\",\"model_id\":\"APPLEWATCH\",\"type\":\"BODY\",\"track\":true,\"prmac\":true,\"state\":\"unlocked\"}",
     "{\"brand\":\"Aranet\",\"model\":\"Aranet4 CO₂ Monitor\",\"model_id\":\"ARANET4\",\"type\":\"AIR\",\"tempc\":26,\"tempf\":78.8,\"hum\":19,\"pres\":804,\"co2\":879,\"batt\":98}",
     "{\"brand\":\"Aranet\",\"model\":\"Aranet4 CO₂ Monitor\",\"model_id\":\"ARANET4\",\"type\":\"AIR\",\"tempc\":26.3,\"tempf\":79.34,\"hum\":17,\"pres\":803.2,\"co2\":844,\"batt\":98}",
+    "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"state\":\"locked\"}",
+    "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"state\":\"locked\"}",
+    "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"state\":\"unlocked recent authenticated interaction\"}",
+    "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"state\":\"locked\"}",
+    "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"state\":\"locked\"}",
+    "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"state\":\"unlocked recent authenticated interaction\"}",
 };
 
 const char* expected_name_uuid_mfgsvcdata[] = {
@@ -520,6 +526,12 @@ const char* test_mfgdata[][3] = {
     {"Apple", "Watch", "4c0010050b982068dd"},
     {"Aranet", "Aranet4", "0207210e0401000c0f016f030802681f1362012c018c00b9"},
     {"Aranet", "Aranet4", "0207210e0401000c0f014c030e02601f1162012c01b10036"},
+    {"Apple", "iPhone", "4c0010061a1e16ec7f61"},
+    {"Apple", "iPhone", "4c0010065a1e02711c95"},
+    {"Apple", "iPhone", "4c0010065b1e02711c91"},
+    {"Apple", "iPad", "4c0010020304"},
+    {"Apple", "iPad", "4c0010020704"},
+    {"Apple", "iPad", "4c0010050b1c93fbf5"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
@@ -639,6 +651,12 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::APPLEWATCH,
     TheengsDecoder::BLE_ID_NUM::ARANET4,
     TheengsDecoder::BLE_ID_NUM::ARANET4,
+    TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
+    TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
+    TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
+    TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
+    TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
+    TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
 };
 
 // uuid test input [test name] [device name] [uuid] [manufacturer data] [service data]


### PR DESCRIPTION
Test for additional Apple devices (iPhone/iPad) with locked/unlocked recent authenticated interaction state for Theengs Gateway Identity MAC/IRK implementation

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
