### PR TITLE
[CI] Upload Python package as artifact

### DIFF
--- a/.github/workflows/PR_build.yml
+++ b/.github/workflows/PR_build.yml
@@ -162,3 +162,7 @@ jobs:
         cd python
         cp -r ../src .
         python3 setup.py sdist
+    - uses: actions/upload-artifact@v4
+      with:
+        name: python-package
+        path: python/dist/*


### PR DESCRIPTION
## Description:

Uploads the Python package built from a PR as an artifact, useful when we need a user to test a change. This doesn't require the user to set up a development environment. We can just let the user download the Python package from the artifacts in a GitHub Action run such as https://github.com/theengs/decoder/actions/runs/7309688303 and let them run `pip install <PACKAGE_FILE>`.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
