### PR TITLE
Add device decoder: TicWatch GTH & GTH Pro (GTH+).

### DIFF
--- a/src/devices/TicWatchGTH_json.h
+++ b/src/devices/TicWatchGTH_json.h
@@ -4,7 +4,7 @@ R""""(
    "model":"GTH/GTH Pro",
    "model_id":"TICWATCHGTH",
    "condition":["name", "index", 0, "TicWatch GTH"],
-   "tag": "0x0f0b",
+   "tag": "0f0b",
    "properties":{
       "mac":{
          "decoder":["value_from_hex_data", "manufacturerdata", 4]

--- a/src/devices/TicWatchGTH_json.h
+++ b/src/devices/TicWatchGTH_json.h
@@ -1,0 +1,13 @@
+R""""(
+{
+   "brand":"TicWatch",
+   "model":"GTH/GTH Pro",
+   "model_id":"TICWATCHGTH",
+   "condition":["name", "index", 0, "TicWatch GTH"],
+   "tag": "0x0f0b",
+   "properties":{
+      "mac":{
+         "decoder":["value_from_hex_data", "manufacturerdata", 4]
+      },
+   }
+})"""",


### PR DESCRIPTION
First attempt at any decoder for a device. Please check carefully/make suggestions for the rest of it, and help me do a decent job, perhaps update docs for unclear things I mention below, and see my comments:
 - Invented a (unique) model_id.
 - Condition checks name starts with TicWatch GTH (Pro version adds '+'). Name suffixed by a space and last 4 characters of MAC).
 - Properties: mac decoder from manufacturer data (offset 4 hex digits, ie 0000<mac> in usual printed order)
 - Tag: picked 11(Body) type (vs.16). Not an RMAC. Believe continuous/active scanning may be best (how to tell? TheengsDecoder Gateway updates mqtt with rssi value regularly as is; is not cidc compliant, reports Ericsson AB mfr but Mobvoi/Ticwatch no known connection to them).
 - (Assumed "byte[0]" from adding-decoders doc is lsb not first digits in value. Is hex representation ok?

## Description:
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
