### PR TITLE
"no-mfgdata" model condition implementation

### DIFF
--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -205,6 +205,8 @@ making sure the additional AND condition is at the end. This has the same result
 Example: `"condition": ["servicedata", "index", 30, "!", "abcd", "&", "servicedata", "index", 0, "1234"]  
 If the value of the service data at index 30 is not 0xabcd and the data at index 0 is 0x1234, the result is a positive detection.
 
+`condition` "no-mfgdata"; This single argument condition allows to test for the non-existence of manufacturerdata in the received advertising data. 
+
 ### Properties
 Properties is a nested JSON object containing one or more JSON objects. In the example above it looks like:
 ```

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -228,6 +228,8 @@ bool TheengsDecoder::checkDeviceMatch(const JsonArray& condition,
           break;
         }
       }
+    } else if (mfg_data == nullptr && strstr(cond_str, "no-mfgdata") != nullptr) {
+      match = true;
     } else if (dev_name != nullptr && strstr(cond_str, "name") != nullptr) {
       cmp_str = dev_name;
     } else if (svc_uuid != nullptr && strstr(cond_str, "uuid") != nullptr) {
@@ -609,7 +611,7 @@ int TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
             doc["track"] = true;
             jsondata["track"] = doc["track"];
           }
-          
+
           // bits[7-4]
           data = getBinaryData(tagstring[2]);
 

--- a/src/devices/tracker_json.h
+++ b/src/devices/tracker_json.h
@@ -58,14 +58,14 @@ const char* _tracker_json_tagit = "{\"brand\":\"Tag-It\",\"model\":\"Smart Track
    }
 })"""";*/
 
-const char* _tracker_json_tile = "{\"brand\":\"Tile\",\"model\":\"Smart Tracker\",\"model_id\":\"TILE\",\"tag\":\"100f\",\"condition\":[\"uuid\",\"index\",0,\"feed\",\"|\",\"uuid\",\"index\",0,\"feec\",\"|\",\"uuid\",\"index\",0,\"fd84\"],\"properties\":{\"device\":{\"decoder\":[\"static_value\",\"Tile Tracker\"]}}}";
+const char* _tracker_json_tile = "{\"brand\":\"Tile\",\"model\":\"Smart Tracker\",\"model_id\":\"TILE\",\"tag\":\"100f\",\"condition\":[\"uuid\",\"index\",0,\"feed\",\"|\",\"uuid\",\"index\",0,\"feec\",\"|\",\"uuid\",\"index\",0,\"fd84\",\"&\",\"no-mfgdata\"],\"properties\":{\"device\":{\"decoder\":[\"static_value\",\"Tile Tracker\"]}}}";
 /*R""""(
 {
    "brand":"Tile",
    "model":"Smart Tracker",
    "model_id":"TILE",
    "tag":"100f",
-   "condition":["uuid", "index", 0, "feed", "|", "uuid", "index", 0, "feec", "|", "uuid", "index", 0, "fd84"],
+   "condition":["uuid", "index", 0, "feed", "|", "uuid", "index", 0, "feec", "|", "uuid", "index", 0, "fd84", "&", "no-mfgdata"],
    "properties":{
       "device":{
          "decoder":["static_value", "Tile Tracker"]


### PR DESCRIPTION
"no-mfgdata" model condition implementation and application in the Tile tracker decoder

https://github.com/theengs/decoder/issues/505

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
