### PR TITLE
Theengs iBeacon Trackers

### DIFF
--- a/src/decoder.h
+++ b/src/decoder.h
@@ -133,6 +133,8 @@ public:
     TAGIT,
     TILE,
     TILEN,
+    TheengsIB01,
+    TheengsIB02,
     JAALEE,
     APPLEWATCH,
     APPLEDEVICE,

--- a/src/devices.h
+++ b/src/devices.h
@@ -199,6 +199,8 @@ const char* _devices[][2] = {
     {_tracker_json_tagit, _tracker_json_props},
     {_tracker_json_tile, _tracker_json_props},
     {_tracker_json_tilename, _tracker_json_props},
+    {_tracker_json_theengs01, _tracker_json_props},
+    {_tracker_json_theengs02, _tracker_json_props},
     {_JAALEE_json, _JAALEE_json_props},
     {_APPLEWATCH_json, _APPLEWATCH_json_props},
     {_APPLEDEVICE_json, _APPLEDEVICE_json_props},

--- a/src/devices/tracker_json.h
+++ b/src/devices/tracker_json.h
@@ -88,6 +88,36 @@ const char* _tracker_json_tilename = "{\"brand\":\"Tile\",\"model\":\"Smart Trac
    }
 })"""";*/
 
+const char* _tracker_json_theengs01 = "{\"brand\":\"Theengs\",\"model\":\"iBeacon Tracker\",\"model_id\":\"TheengsIB01\",\"tag\":\"1009\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c000215546865656e67732d69426561636f6e31\"],\"properties\":{\"device\":{\"decoder\":[\"static_value\",\"Theengs iBeacon Tracker\"]}}}";
+/*R""""(
+{
+   "brand":"Theengs",
+   "model":"iBeacon Tracker",
+   "model_id":"TheengsIB01",
+   "tag":"1009",
+   "condition":["manufacturerdata", "=", 50, "index", 0, "4c000215546865656e67732d69426561636f6e31"],
+   "properties":{
+      "device":{
+         "decoder":["static_value", "Theengs iBeacon Tracker"]
+      }
+   }
+})"""";*/
+
+const char* _tracker_json_theengs02 = "{\"brand\":\"Theengs\",\"model\":\"iBeacon Tracker\",\"model_id\":\"TheengsIB02\",\"tag\":\"1019\",\"condition\":[\"manufacturerdata\",\"=\",50,\"index\",0,\"4c000215546865656e67732d69426561636f6e32\"],\"properties\":{\"device\":{\"decoder\":[\"static_value\",\"Theengs iBeacon Tracker\"]}}}";
+/*R""""(
+{
+   "brand":"Theengs",
+   "model":"iBeacon Tracker",
+   "model_id":"TheengsIB02",
+   "tag":"1019",
+   "condition":["manufacturerdata", "=", 50, "index", 0, "4c000215546865656e67732d69426561636f6e32"],
+   "properties":{
+      "device":{
+         "decoder":["static_value", "Theengs iBeacon Tracker"]
+      }
+   }
+})"""";*/
+
 const char* _tracker_json_props = "{\"properties\":{\"device\":{\"unit\":\"string\",\"name\":\"tracker device\"}}}";
 /*R""""(
 {

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -142,6 +142,8 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"unlocked\":false}",
     "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"unlocked\":false}",
     "{\"brand\":\"Apple\",\"model\":\"Apple iPhone/iPad\",\"model_id\":\"APPLEDEVICE\",\"type\":\"TRACK\",\"track\":true,\"prmac\":true,\"unlocked\":true}",
+    "{\"brand\":\"Theengs\",\"model\":\"iBeacon Tracker\",\"model_id\":\"TheengsIB01\",\"type\":\"TRACK\",\"cidc\":false,\"track\":true,\"device\":\"Theengs iBeacon Tracker\"}",
+    "{\"brand\":\"Theengs\",\"model\":\"iBeacon Tracker\",\"model_id\":\"TheengsIB02\",\"type\":\"TRACK\",\"cidc\":false,\"track\":true,\"prmac\":true,\"device\":\"Theengs iBeacon Tracker\"}",
 };
 
 const char* expected_name_uuid_mfgsvcdata[] = {
@@ -534,6 +536,8 @@ const char* test_mfgdata[][3] = {
     {"Apple", "iPad", "4c0010020304"},
     {"Apple", "iPad", "4c0010020704"},
     {"Apple", "iPad", "4c0010050b1c93fbf5"},
+    {"BM2", "Battery Monitor", "4c000215546865656e67732d69426561636f6e31f644000064"},
+    {"BM2", "Battery Monitor", "4c000215546865656e67732d69426561636f6e32f644000064"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
@@ -659,6 +663,8 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
     TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
     TheengsDecoder::BLE_ID_NUM::APPLEDEVICE,
+    TheengsDecoder::BLE_ID_NUM::TheengsIB01,
+    TheengsDecoder::BLE_ID_NUM::TheengsIB02,
 };
 
 // uuid test input [test name] [device name] [uuid] [manufacturer data] [service data]


### PR DESCRIPTION
For hardware programmable or software simulating iBeacons, set the following uuid

• for static Bluetooth MAC address
546865656E67732D69426561636F6E31

• for randomly changing Bluetooth MAC address
546865656E67732D69426561636F6E32

Randomly changing Bluetooth MAC address is currently only usefully working with the the Theengs Gateway Identity Address and IRK functionality, if you know these details of your device.

Major and Minor definitions are not taken into account and can be set freely.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
