### PR TITLE
Feasycom beacon model BP102 added

### DIFF
--- a/src/devices/FEASY_json.h
+++ b/src/devices/FEASY_json.h
@@ -1,4 +1,4 @@
-const char* _FEASY_json = "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_id\":\"FEASY\",\"tag\":\"0608\",\"condition\":[\"servicedata\",\"=\",22,\"&\",\"uuid\",\"index\",0,\"fff0\"],\"properties\":{\"beaconmodel\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",0,2,false,false],\"lookup\":[\"19\",\"BP109\",\"1a\",\"BP103\",\"1b\",\"BP104\",\"1c\",\"BP201\",\"1d\",\"BP106\",\"1e\",\"BP101\",\"24\",\"BP120\",\"27\",\"BP108\",\"28\",\"BP108N\"]},\"batt\":{\"condition\":[\"servicedata\",20,\"!\",\"65\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",20,2,false,false],\"post_proc\":[\"&\",127]},\"plugged-in\":{\"condition\":[\"servicedata\",20,\"65\"],\"decoder\":[\"static_value\",true]},\"_plugged-in\":{\"condition\":[\"servicedata\",20,\"!\",\"65\"],\"decoder\":[\"static_value\",false]},\"mac\":{\"decoder\":[\"mac_from_hex_data\",\"servicedata\",8]}}}";
+const char* _FEASY_json = "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_id\":\"FEASY\",\"tag\":\"0608\",\"condition\":[\"servicedata\",\"=\",22,\"&\",\"uuid\",\"index\",0,\"fff0\"],\"properties\":{\"beaconmodel\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",0,2,false,false],\"lookup\":[\"15\",\"BP102\",\"19\",\"BP109\",\"1a\",\"BP103\",\"1b\",\"BP104\",\"1c\",\"BP201\",\"1d\",\"BP106\",\"1e\",\"BP101\",\"24\",\"BP120\",\"27\",\"BP108\",\"28\",\"BP108N\"]},\"batt\":{\"condition\":[\"servicedata\",20,\"!\",\"65\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",20,2,false,false],\"post_proc\":[\"&\",127]},\"plugged-in\":{\"condition\":[\"servicedata\",20,\"65\"],\"decoder\":[\"static_value\",true]},\"_plugged-in\":{\"condition\":[\"servicedata\",20,\"!\",\"65\"],\"decoder\":[\"static_value\",false]},\"mac\":{\"decoder\":[\"mac_from_hex_data\",\"servicedata\",8]}}}";
 
 /*R""""(
 {
@@ -10,7 +10,8 @@ const char* _FEASY_json = "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_
    "properties":{
       "beaconmodel":{
          "decoder":["string_from_hex_data", "servicedata", 0, 2, false, false],
-         "lookup":["19", "BP109", 
+         "lookup":["15", "BP102", 
+                   "19", "BP109", 
                    "1a", "BP103", 
                    "1b", "BP104", 
                    "1c", "BP201", 


### PR DESCRIPTION
Feasycom beacon model BP102 added to FEASY decoder - somehow got lost

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
