### PR TITLE
fix: compiler warning: dereferencing type-punned pointer will break strict-aliasing rules

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -102,8 +102,11 @@ double TheengsDecoder::value_from_hex_string(const char* data_str,
     value = strtoll(data.c_str(), NULL, 16);
     DEBUG_PRINT("extracted value from %s = %lld\n", data.c_str(), (long long)value);
   } else {
-    long longV = strtol(data.c_str(), NULL, 16);
-    float floatV = *((float*)&longV);
+    union {
+      long longV;
+      float floatV;
+    };
+    longV = strtol(data.c_str(), NULL, 16);
     DEBUG_PRINT("extracted float value from %s = %f\n", data.c_str(), floatV);
     value = floatV;
   }


### PR DESCRIPTION
## Description:
During compilation I get gcc warning: decoder.cpp:106:22: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
This fix allows to compile the library with -Wall -Wextra -Werror parameters


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
