### PR TITLE
Bosch Nyon decoder restriction

### DIFF
--- a/src/devices/tracker_json.h
+++ b/src/devices/tracker_json.h
@@ -148,14 +148,14 @@ const char* _tracker_json_GTAG = "{\"brand\":\"Gigaset\",\"model\":\"G-Tag\",\"m
    }
 })"""";*/
 
-const char* _tracker_json_NYON = "{\"brand\":\"Bosch\",\"model\":\"Nyon\",\"model_id\":\"BOSCHNYON\",\"tag\":\"1008\",\"condition\":[\"manufacturerdata\",\"=\",14,\"index\",0,\"a602\"],\"properties\":{\"device\":{\"decoder\":[\"static_value\",\"Bosch Nyon Tracker\"]}}}";
+const char* _tracker_json_NYON = "{\"brand\":\"Bosch\",\"model\":\"Nyon\",\"model_id\":\"BOSCHNYON\",\"tag\":\"100a\",\"condition\":[\"name\",\"index\",0,\"Nyon\",\"&\",\"manufacturerdata\",\"=\",14,\"index\",0,\"a602\"],\"properties\":{\"device\":{\"decoder\":[\"static_value\",\"Bosch Nyon Tracker\"]}}}";
 /*R""""(
 {
    "brand":"Bosch",
    "model":"Nyon",
    "model_id":"BOSCHNYON",
-   "tag":"1008",
-   "condition":["manufacturerdata", "=", 14, "index", 0, "a602"],
+   "tag":"100a",
+   "condition":["name", "index", 0, "Nyon", "&", "manufacturerdata", "=", 14, "index", 0, "a602"],
    "properties":{
       "device":{
          "decoder":["static_value", "Bosch Nyon Tracker"]

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -160,7 +160,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Otodata\",\"model\":\"Rotarex-compatible Monitor\",\"model_id\":\"RC1010\",\"type\":\"UNIQ\",\"level\":98.35,\"status\":0}",
     "{\"brand\":\"Otodata\",\"model\":\"Rotarex-compatible Monitor\",\"model_id\":\"RC1010\",\"type\":\"UNIQ\",\"serial\":56001608,\"modeltype\":67367466}",
     "{\"brand\":\"Tile\",\"model\":\"Smart Tracker\",\"model_id\":\"TILE\",\"type\":\"TRACK\",\"cidc\":false,\"acts\":true,\"track\":true,\"device\":\"Tile Tracker\"}",
-    "{\"brand\":\"Bosch\",\"model\":\"Nyon\",\"model_id\":\"BOSCHNYON\",\"type\":\"TRACK\",\"track\":true,\"device\":\"Bosch Nyon Tracker\"}",
+    "{\"brand\":\"Bosch\",\"model\":\"Nyon\",\"model_id\":\"BOSCHNYON\",\"type\":\"TRACK\",\"acts\":true,\"track\":true,\"device\":\"Bosch Nyon Tracker\"}",
 };
 
 const char* expected_name_uuid_mfgsvcdata[] = {


### PR DESCRIPTION
More restrictive Bosch Nyon device tracker decoder to also require the name, as to not accidentally pick up any of the many other Bosch Bluetooth devices.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
