### PR TITLE
TP35X/393 batt_low adjustment

### DIFF
--- a/src/devices/TPTH_json.h
+++ b/src/devices/TPTH_json.h
@@ -1,6 +1,6 @@
 #include "common_props.h"
 
-const char* _TPTH_json = "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"TP357\",\"|\",\"name\",\"index\",0,\"TP358\",\"|\",\"name\",\"index\",0,\"TP359\",\"|\",\"name\",\"index\",0,\"TP393\",\"&\",\"manufacturerdata\",\">=\",12,\"index\",0,\"c2\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",2,4,true,true],\"post_proc\":[\"/\",10]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",6,2,false,false]},\"batt_low\":{\"condition\":[\"manufacturerdata\",9,\"bit\",0,1,\"|\",\"manufacturerdata\",9,\"bit\",1,1],\"decoder\":[\"static_value\",false]},\"_batt_low\":{\"condition\":[\"manufacturerdata\",9,\"bit\",0,0,\"&\",\"manufacturerdata\",9,\"bit\",1,0],\"decoder\":[\"static_value\",true]}}}";
+const char* _TPTH_json = "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"TP357\",\"|\",\"name\",\"index\",0,\"TP358\",\"|\",\"name\",\"index\",0,\"TP359\",\"|\",\"name\",\"index\",0,\"TP393\",\"&\",\"manufacturerdata\",\">=\",12,\"index\",0,\"c2\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",2,4,true,true],\"post_proc\":[\"/\",10]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",6,2,false,false]},\"batt_low\":{\"condition\":[\"manufacturerdata\",9,\"bit\",1,1],\"decoder\":[\"static_value\",false]},\"_batt_low\":{\"condition\":[\"manufacturerdata\",9,\"bit\",1,0],\"decoder\":[\"static_value\",true]}}}";
 /*R""""(
 {
    "brand":"ThermoPro",
@@ -17,11 +17,11 @@ const char* _TPTH_json = "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"mod
          "decoder":["value_from_hex_data", "manufacturerdata", 6, 2, false, false]
       },
       "batt_low":{
-         "condition":["manufacturerdata", 9, "bit", 0, 1, "|", "manufacturerdata", 9, "bit", 1, 1],
+         "condition":["manufacturerdata", 9, "bit", 1, 1],
          "decoder":["static_value", false]
       },
       "_batt_low":{
-         "condition":["manufacturerdata", 9, "bit", 0, 0, "&", "manufacturerdata", 9, "bit", 1, 0],
+         "condition":["manufacturerdata", 9, "bit", 1, 0],
          "decoder":["static_value", true]
       }
    }

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -65,7 +65,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":21.4,\"tempf\":70.52,\"hum\":67,\"batt_low\":false}",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":24.5,\"tempf\":76.1,\"hum\":50,\"batt_low\":false",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":24.6,\"tempf\":76.28,\"hum\":51,\"batt_low\":false}",
-    "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":25.5,\"tempf\":77.9,\"hum\":53,\"batt_low\":false}",
+    "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":25.5,\"tempf\":77.9,\"hum\":53,\"batt_low\":true}",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":25.5,\"tempf\":77.9,\"hum\":53,\"batt_low\":true}",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":21.2,\"tempf\":70.16,\"hum\":55,\"batt_low\":false}",
     "{\"brand\":\"Oria\",\"model\":\"TH Sensor\",\"model_id\":\"T301\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":25.6,\"tempf\":78.08,\"hum\":56,\"batt\":99,\"mac\":\"AA:BB:CC:DD:EE:FF\"}",


### PR DESCRIPTION
TP35X/393 batt_low adjustment to already register a low battery with value 1 of 2-1-0, as per user observation in

https://github.com/custom-components/ble_monitor/issues/1422

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
