### PR TITLE
Onset Hobo negative decoder Boolean

### DIFF
--- a/src/devices/HOBOMX2001_json.h
+++ b/src/devices/HOBOMX2001_json.h
@@ -1,4 +1,4 @@
-const char* _HOBOMX2001_json = "{\"brand\":\"Onset\",\"model\":\"Hobo Water Level Sensor\",\"model_id\":\"HOBOMX2001\",\"tag\":\"ff\",\"condition\":[\"manufacturerdata\",\"=\",44,\"index\",0,\"c500\"],\"properties\":{\"lvl_cm\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,8,true,false,true],\"post_proc\":[\"*\",100]}}}";
+const char* _HOBOMX2001_json = "{\"brand\":\"Onset\",\"model\":\"Hobo Water Level Sensor\",\"model_id\":\"HOBOMX2001\",\"tag\":\"ff\",\"condition\":[\"manufacturerdata\",\"=\",44,\"index\",0,\"c500\"],\"properties\":{\"lvl_cm\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",36,8,true,true,true],\"post_proc\":[\"*\",100]}}}";
 /* R""""(
 {
    "brand":"Onset",
@@ -8,7 +8,7 @@ const char* _HOBOMX2001_json = "{\"brand\":\"Onset\",\"model\":\"Hobo Water Leve
    "condition":["manufacturerdata", "=", 44, "index", 0, "c500"],
    "properties":{
       "lvl_cm":{
-         "decoder":["value_from_hex_data", "manufacturerdata", 36, 8, true, false, true],
+         "decoder":["value_from_hex_data", "manufacturerdata", 36, 8, true, true, true],
          "post_proc":["*", 100]
       }
    }


### PR DESCRIPTION
Does not really make any change to the current float decoding, but good to have as indication that decoded values can be negative

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
