### PR TITLE
Fix build system: proper setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,25 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]
+requires = [
+    # packaging engine
+    "setuptools >= 61",
+    "wheel",
+    # C/C++ build glue
+    "scikit-build >= 0.17",          # or scikit-build-core >= 0.11.2
+    "cmake >= 3.18",
+    "ninja",
+    "pybind11 >= 2.9.0",
+    # version extraction
+    "setuptools_scm[toml] >= 8",
+]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+root = ".."
+relative_to = "python/pyproject.toml"
+version_scheme = "post-release"
+local_scheme   = "no-local-version"
+
+[tool.setuptools]
+packages = ["TheengsDecoder"]
+package-dir = { "" = "." }
+include-package-data = true


### PR DESCRIPTION
## Description:
This is an attempt to fix the wheel building so that Theengs Decoder is available in [piwheels](https://www.piwheels.org/project/theengsdecoder/)
Goal is to support older board like Raspberry Pi zero by providing a ready to install wheel. Building on the zero fail or run for a long time currently.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
