### PR TITLE
Add Feasycom BP104D, json HA compatible

### DIFF
--- a/.github/workflows/PR_build.yml
+++ b/.github/workflows/PR_build.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/src/devices/FEASY_json.h
+++ b/src/devices/FEASY_json.h
@@ -1,4 +1,4 @@
-const char* _FEASY_json = "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_id\":\"FEASY\",\"tag\":\"0608\",\"condition\":[\"servicedata\",\"=\",22,\"&\",\"uuid\",\"index\",0,\"fff0\"],\"properties\":{\"beaconmodel\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",0,2,false,false],\"lookup\":[\"15\",\"BP102\",\"19\",\"BP109\",\"1a\",\"BP103\",\"1b\",\"BP104\",\"1c\",\"BP201\",\"1d\",\"BP106\",\"1e\",\"BP101\",\"24\",\"BP120\",\"27\",\"BP108\",\"28\",\"BP108N\",\"29\",\"BP103B\"]},\"batt\":{\"condition\":[\"servicedata\",20,\"!\",\"65\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",20,2,false,false],\"post_proc\":[\"&\",127]},\"plugged-in\":{\"condition\":[\"servicedata\",20,\"65\"],\"decoder\":[\"static_value\",true]},\"_plugged-in\":{\"condition\":[\"servicedata\",20,\"!\",\"65\"],\"decoder\":[\"static_value\",false]},\"mac\":{\"decoder\":[\"mac_from_hex_data\",\"servicedata\",8]}}}";
+const char* _FEASY_json = "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_id\":\"FEASY\",\"tag\":\"0608\",\"condition\":[\"servicedata\",\"=\",22,\"&\",\"uuid\",\"index\",0,\"fff0\"],\"properties\":{\"beaconmodel\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",0,2,false,false],\"lookup\":[\"15\",\"BP102\",\"19\",\"BP109\",\"1a\",\"BP103\",\"1b\",\"BP104\",\"1c\",\"BP201\",\"1d\",\"BP106\",\"1e\",\"BP101\",\"24\",\"BP120\",\"27\",\"BP108\",\"28\",\"BP108N\",\"29\",\"BP103B\",\"46\",\"BP104D\"]},\"batt\":{\"condition\":[\"servicedata\",20,\"!\",\"65\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",20,2,false,false],\"post_proc\":[\"&\",127]},\"plugged_in\":{\"condition\":[\"servicedata\",20,\"65\"],\"decoder\":[\"static_value\",true]},\"_plugged_in\":{\"condition\":[\"servicedata\",20,\"!\",\"65\"],\"decoder\":[\"static_value\",false]},\"mac\":{\"decoder\":[\"mac_from_hex_data\",\"servicedata\",8]}}}";
 
 /*R""""(
 {
@@ -20,18 +20,19 @@ const char* _FEASY_json = "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_
                    "24", "BP120", 
                    "27", "BP108", 
                    "28", "BP108N",
-                   "29", "BP103B"]
+                   "29", "BP103B",
+                   "46", "BP104D"]
       },
       "batt":{
          "condition":["servicedata", 20, "!", "65"],
          "decoder":["value_from_hex_data", "servicedata", 20, 2, false, false],
          "post_proc":["&", 127]
       },
-      "plugged-in":{
+      "plugged_in":{
          "condition":["servicedata", 20, "65"],
          "decoder":["static_value", true]
       },
-      "_plugged-in":{
+      "_plugged_in":{
          "condition":["servicedata", 20, "!", "65"],
          "decoder":["static_value", false]
       },
@@ -41,7 +42,7 @@ const char* _FEASY_json = "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_
    }
 })"""";*/
 
-const char* _FEASY_json_props = "{\"properties\":{\"beaconmodel\":{\"unit\":\"string\",\"name\":\"beacon model\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"plugged-in\":{\"unit\":\"status\",\"name\":\"plug\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
+const char* _FEASY_json_props = "{\"properties\":{\"beaconmodel\":{\"unit\":\"string\",\"name\":\"beacon model\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"plugged_in\":{\"unit\":\"status\",\"name\":\"plug\"},\"mac\":{\"unit\":\"string\",\"name\":\"MAC address\"}}}";
 /*R""""(
 {
    "properties":{
@@ -53,7 +54,7 @@ const char* _FEASY_json_props = "{\"properties\":{\"beaconmodel\":{\"unit\":\"st
          "unit":"%",
          "name":"battery"
       },
-      "plugged-in":{
+      "plugged_in":{
          "unit":"status",
          "name":"plug"
       },

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -505,8 +505,8 @@ const char* expected_uuid[] = {
     "{\"brand\":\"NodOn\",\"model\":\"NIU smart button\",\"model_id\":\"NODONNIU\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"track\":true,\"button\":9,\"color\":\"Lagoon\",\"batt\":96}",
     "{\"brand\":\"NodOn\",\"model\":\"NIU smart button\",\"model_id\":\"NODONNIU\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"track\":true,\"button\":10,\"color\":\"Lagoon\",\"batt\":98}",
     "{\"brand\":\"NodOn\",\"model\":\"NIU smart button\",\"model_id\":\"NODONNIU\",\"type\":\"BTN\",\"acts\":true,\"cont\":true,\"track\":true,\"button\":3,\"color\":\"CozyGrey\",\"batt\":89}",
-    "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_id\":\"FEASY\",\"type\":\"BCON\",\"track\":true,\"beaconmodel\":\"BP108\",\"batt\":100,\"plugged-in\":false,\"mac\":\"AA:BB:CC:DD:EE:FF\"}",
-    "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_id\":\"FEASY\",\"type\":\"BCON\",\"track\":true,\"beaconmodel\":\"BP103B\",\"batt\":100,\"plugged-in\":false,\"mac\":\"AA:BB:CC:DD:EE:FF\"}",
+    "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_id\":\"FEASY\",\"type\":\"BCON\",\"track\":true,\"beaconmodel\":\"BP108\",\"batt\":100,\"plugged_in\":false,\"mac\":\"AA:BB:CC:DD:EE:FF\"}",
+    "{\"brand\":\"Feasycom\",\"model\":\"Beacon\",\"model_id\":\"FEASY\",\"type\":\"BCON\",\"track\":true,\"beaconmodel\":\"BP103B\",\"batt\":100,\"plugged_in\":false,\"mac\":\"AA:BB:CC:DD:EE:FF\"}",
     "{\"brand\":\"BlueCharm\",\"model\":\"Beacon 08/04P/021\",\"model_id\":\"KSensor\",\"type\":\"ACEL\",\"track\":true,\"tempc\":21.25,\"tempf\":70.25,\"accx\":4,\"accy\":-12,\"accz\":-4,\"volt\":3.05}",
     "{\"brand\":\"ClearGrass/Qingping\",\"model\":\"Thermo-Hygrometer CO2 Detector\",\"model_id\":\"CGP22C\",\"type\":\"AIR\",\"tempc\":25.5,\"tempf\":77.9,\"hum\":43.1,\"co2\":583,\"batt\":100,\"mac\":\"AA:BB:CC:DD:EE:FF\"}",
 };


### PR DESCRIPTION
## Description:
Added additional Feasycom device
HA doesn't like json with '-' character, so have substituted this in plugged-in for plugged_in wherever this appears in Feasycom file.
Code not compiled as only changes to json library

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
