### PR TITLE
Adjust model_id for both LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME

### DIFF
--- a/src/devices/LYWSD03MMC_ENCR_json.h
+++ b/src/devices/LYWSD03MMC_ENCR_json.h
@@ -19,12 +19,12 @@ const char* _LYWSD03MMC_ENCR_json_PVVX = "{\"brand\":\"Xiaomi\",\"model\":\"TH S
    }
 })"""";*/
 
-const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_1_ENCR\",\"tag\":\"010202\",\"condition\":[\"servicedata\",\"=\",34,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,16]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",18,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",26,8]}}}";
+const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010202\",\"condition\":[\"servicedata\",\"=\",34,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,16]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",18,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",26,8]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
-   "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_1_ENCR",
+   "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR",
    "tag":"010202",
    "condition":["servicedata", "=", 34, "index", 0, "41", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
@@ -40,12 +40,12 @@ const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model
    }
 })"""";*/
 
-const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_2_ENCR\",\"tag\":\"010202\",\"condition\":[\"servicedata\",\"=\",32,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,14]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",16,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",24,8]}}}";
+const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010202\",\"condition\":[\"servicedata\",\"=\",32,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,14]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",16,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",24,8]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
-   "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_2_ENCR",
+   "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR",
    "tag":"010202",
    "condition":["servicedata", "=", 32, "index", 0, "41", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{

--- a/src/devices/LYWSD03MMC_json.h
+++ b/src/devices/LYWSD03MMC_json.h
@@ -82,12 +82,12 @@ const char* _LYWSD03MMC_json_PVVX_DECR = "{\"brand\":\"Xiaomi\",\"model\":\"TH S
    }
 })"""";*/
 
-const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_1\",\"tag\":\"0102\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",10,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",16,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]}}}";
+const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0102\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",10,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",16,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
-   "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_1",
+   "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME",
    "tag":"0102",
    "condition":["servicedata", "=", 22, "index", 0, "40", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
@@ -112,12 +112,12 @@ const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"
    }
 })"""";*/
 
-const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_2\",\"tag\":\"0102\",\"condition\":[\"servicedata\",\"=\",20,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",6,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,false],\"post_proc\":[\"/\",1000]},\"power\":{\"condition\":[\"servicedata\",12,\"10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,2,false,false]},\"opening\":{\"condition\":[\"servicedata\",16,\"11\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,2,false,false]}}}";
+const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0102\",\"condition\":[\"servicedata\",\"=\",20,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",6,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,false],\"post_proc\":[\"/\",1000]},\"power\":{\"condition\":[\"servicedata\",12,\"10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,2,false,false]},\"opening\":{\"condition\":[\"servicedata\",16,\"11\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,2,false,false]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
-   "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_2",
+   "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME",
    "tag":"0102",
    "condition":["servicedata", "=", 20, "index", 0, "40", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -371,10 +371,10 @@ const char* expected_uuid_name_svcdata[] = {
     "{\"brand\":\"Sensor Easy\",\"model\":\"SE MAG\",\"model_id\":\"SE_MAG\",\"type\":\"CTMO\",\"open\":false,\"cont\":true}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Outdoor Meter\",\"model_id\":\"W340001X\",\"type\":\"THB\",\"batt\":65}",
     "{\"brand\":\"Tuya\",\"model\":\"THB1 Thermo-Hygrometer\",\"model_id\":\"THB1\",\"type\":\"THB\",\"acts\":true,\"packet\":239,\"tempc\":17.94,\"tempf\":64.292,\"hum\":60.72,\"batt\":74,\"volt\":2.748}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_1\",\"type\":\"THB\",\"acts\":true,\"packet\":132,\"tempc\":20.79,\"tempf\":69.422,\"hum\":71.88,\"batt\":100}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_2\",\"type\":\"THB\",\"acts\":true,\"packet\":129,\"volt\":3.034,\"power\":1,\"opening\":1}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_1_ENCR\",\"type\":\"THB\",\"acts\":true,\"encr\":2,\"cipher\":\"d19a92d016e70700\",\"ctr\":\"a80c0000\",\"mic\":\"7e2ed06b\"}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_2_ENCR\",\"type\":\"THB\",\"acts\":true,\"encr\":2,\"cipher\":\"426c816642734c\",\"ctr\":\"a20c0000\",\"mic\":\"66feb71b\"}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"acts\":true,\"packet\":132,\"tempc\":20.79,\"tempf\":69.422,\"hum\":71.88,\"batt\":100}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"acts\":true,\"packet\":129,\"volt\":3.034,\"power\":1,\"opening\":1}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"acts\":true,\"encr\":2,\"cipher\":\"be07860de133b342\",\"ctr\":\"23020000\",\"mic\":\"50dea27d\"}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"acts\":true,\"encr\":2,\"cipher\":\"613c80e969f052\",\"ctr\":\"a9000000\",\"mic\":\"77b39384\"}",
 };
 
 const char* expected_uuid[] = {
@@ -1203,8 +1203,8 @@ const char* test_uuid_name_svcdata[][4] = {
     {"THB1 PVVX", "0xfcd2", "THB1-3F9E5D", "4000ef014a02020703b8170cbc0a"},
     {"LYWSD03MMC_PVVX_BTHOME_1", "0xfcd2", "ATC_112233", "4000840164021f0803141c"},
     {"LYWSD03MMC_PVVX_BTHOME_2", "0xfcd2", "ATC_112233", "4000810cda0b10011101"},
-    {"LYWSD03MMC_PVVX_BTHOME_1_ENCR", "0xfcd2", "ATC_112233", "41d19a92d016e70700a80c00007e2ed06b"},  // AES Key 00112233445566778899001122334455
-    {"LYWSD03MMC_PVVX_BTHOME_2_ENCR", "0xfcd2", "ATC_112233", "41426c816642734ca20c000066feb71b"},  // AES Key 00112233445566778899001122334455
+    {"LYWSD03MMC_PVVX_BTHOME_1_ENCR", "0xfcd2", "ATC_77B4FC", "41be07860de133b3422302000050dea27d"},  // MAC Address A4:C1:38:77:B4:FC - AES Key 00112233445566778899001122334455
+    {"LYWSD03MMC_PVVX_BTHOME_2_ENCR", "0xfcd2", "ATC_77B4FC", "41613c80e969f052a900000077b39384"},  // MAC Address A4:C1:38:77:B4:FC - AES Key 00112233445566778899001122334455
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{


### PR DESCRIPTION
Adjust model_id for both LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME frames removing the _1 and _2 to match to resolve issues with OpenMQTTGateway

## Description:

When testing the updated LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME decoder with OpenMQTTGateway there is an issue as the `model_id` is used in the device name. Since I mistakenly had different `model_id`'s for the different frames then OpenMQTTGateway flip flops between the two names and that then flows into Home Assistant.

I am working on adding Encrypted BTHome support to OpenMQTTGateway as well. What it should be doing is checking for the `acts` so it will know there is additional frames that need to be supported. 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
