### PR TITLE
Change LYWSD03MMC BTHome from active to just continuous scanning

### DIFF
--- a/src/devices/LYWSD03MMC_ENCR_json.h
+++ b/src/devices/LYWSD03MMC_ENCR_json.h
@@ -19,13 +19,13 @@ const char* _LYWSD03MMC_ENCR_json_PVVX = "{\"brand\":\"Xiaomi\",\"model\":\"TH S
    }
 })"""";*/
 
-const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010602\",\"condition\":[\"servicedata\",\"=\",34,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,16]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",18,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",26,8]}}}";
+const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010402\",\"condition\":[\"servicedata\",\"=\",34,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,16]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",18,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",26,8]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
    "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR",
-   "tag":"010602",
+   "tag":"010402",
    "condition":["servicedata", "=", 34, "index", 0, "41", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
       "cipher":{
@@ -40,13 +40,13 @@ const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model
    }
 })"""";*/
 
-const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010602\",\"condition\":[\"servicedata\",\"=\",32,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,14]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",16,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",24,8]}}}";
+const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010402\",\"condition\":[\"servicedata\",\"=\",32,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,14]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",16,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",24,8]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
    "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR",
-   "tag":"010602",
+   "tag":"010402",
    "condition":["servicedata", "=", 32, "index", 0, "41", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
       "cipher":{

--- a/src/devices/LYWSD03MMC_ENCR_json.h
+++ b/src/devices/LYWSD03MMC_ENCR_json.h
@@ -19,13 +19,13 @@ const char* _LYWSD03MMC_ENCR_json_PVVX = "{\"brand\":\"Xiaomi\",\"model\":\"TH S
    }
 })"""";*/
 
-const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010202\",\"condition\":[\"servicedata\",\"=\",34,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,16]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",18,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",26,8]}}}";
+const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010602\",\"condition\":[\"servicedata\",\"=\",34,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,16]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",18,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",26,8]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
    "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR",
-   "tag":"010202",
+   "tag":"010602",
    "condition":["servicedata", "=", 34, "index", 0, "41", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
       "cipher":{
@@ -40,13 +40,13 @@ const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model
    }
 })"""";*/
 
-const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010202\",\"condition\":[\"servicedata\",\"=\",32,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,14]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",16,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",24,8]}}}";
+const char* _LYWSD03MMC_ENCR_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"tag\":\"010602\",\"condition\":[\"servicedata\",\"=\",32,\"index\",0,\"41\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"cipher\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",2,14]},\"ctr\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",16,8]},\"mic\":{\"decoder\":[\"string_from_hex_data\",\"servicedata\",24,8]}}}";
 /*R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
    "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR",
-   "tag":"010202",
+   "tag":"010602",
    "condition":["servicedata", "=", 32, "index", 0, "41", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
       "cipher":{

--- a/src/devices/LYWSD03MMC_json.h
+++ b/src/devices/LYWSD03MMC_json.h
@@ -82,13 +82,13 @@ const char* _LYWSD03MMC_json_PVVX_DECR = "{\"brand\":\"Xiaomi\",\"model\":\"TH S
    }
 })"""";*/
 
-const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0106\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",10,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",16,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]}}}";
+const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0104\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",10,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",16,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
    "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME",
-   "tag":"0106",
+   "tag":"0104",
    "condition":["servicedata", "=", 22, "index", 0, "40", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
       "packet":{
@@ -112,13 +112,13 @@ const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"
    }
 })"""";*/
 
-const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0106\",\"condition\":[\"servicedata\",\"=\",20,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",6,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,false],\"post_proc\":[\"/\",1000]},\"power\":{\"condition\":[\"servicedata\",12,\"10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,2,false,false]},\"opening\":{\"condition\":[\"servicedata\",16,\"11\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,2,false,false]}}}";
+const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0104\",\"condition\":[\"servicedata\",\"=\",20,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",6,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,false],\"post_proc\":[\"/\",1000]},\"power\":{\"condition\":[\"servicedata\",12,\"10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,2,false,false]},\"opening\":{\"condition\":[\"servicedata\",16,\"11\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,2,false,false]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
    "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME",
-   "tag":"0106",
+   "tag":"0104",
    "condition":["servicedata", "=", 20, "index", 0, "40", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
       "packet":{

--- a/src/devices/LYWSD03MMC_json.h
+++ b/src/devices/LYWSD03MMC_json.h
@@ -82,13 +82,13 @@ const char* _LYWSD03MMC_json_PVVX_DECR = "{\"brand\":\"Xiaomi\",\"model\":\"TH S
    }
 })"""";*/
 
-const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0102\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",10,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",16,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]}}}";
+const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0106\",\"condition\":[\"servicedata\",\"=\",22,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",10,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",16,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
    "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME",
-   "tag":"0102",
+   "tag":"0106",
    "condition":["servicedata", "=", 22, "index", 0, "40", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
       "packet":{
@@ -112,13 +112,13 @@ const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"
    }
 })"""";*/
 
-const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0102\",\"condition\":[\"servicedata\",\"=\",20,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",6,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,false],\"post_proc\":[\"/\",1000]},\"power\":{\"condition\":[\"servicedata\",12,\"10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,2,false,false]},\"opening\":{\"condition\":[\"servicedata\",16,\"11\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,2,false,false]}}}";
+const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0106\",\"condition\":[\"servicedata\",\"=\",20,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",6,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,false],\"post_proc\":[\"/\",1000]},\"power\":{\"condition\":[\"servicedata\",12,\"10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,2,false,false]},\"opening\":{\"condition\":[\"servicedata\",16,\"11\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,2,false,false]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
    "model":"TH Sensor",
    "model_id":"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME",
-   "tag":"0102",
+   "tag":"0106",
    "condition":["servicedata", "=", 20, "index", 0, "40", "&", "uuid", "index", 0, "fcd2", "&", "name", "index", 0, "ATC"],
    "properties":{
       "packet":{

--- a/src/devices/LYWSD03MMC_json.h
+++ b/src/devices/LYWSD03MMC_json.h
@@ -112,7 +112,7 @@ const char* _LYWSD03MMC_json_PVVX_BTHOME_1 = "{\"brand\":\"Xiaomi\",\"model\":\"
    }
 })"""";*/
 
-const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0104\",\"condition\":[\"servicedata\",\"=\",20,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",6,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,false],\"post_proc\":[\"/\",1000]},\"power\":{\"condition\":[\"servicedata\",12,\"10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,2,false,false]},\"opening\":{\"condition\":[\"servicedata\",16,\"11\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,2,false,false]}}}";
+const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"tag\":\"0104\",\"condition\":[\"servicedata\",\"=\",20,\"index\",0,\"40\",\"&\",\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"index\",0,\"ATC\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",6,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,4,true,false],\"post_proc\":[\"/\",1000]},\"power\":{\"condition\":[\"servicedata\",12,\"10\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",14,2,false,false]},\"open\":{\"condition\":[\"servicedata\",16,\"11\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,2,false,false]}}}";
 /* R""""(
 {
    "brand":"Xiaomi",
@@ -134,7 +134,7 @@ const char* _LYWSD03MMC_json_PVVX_BTHOME_2 = "{\"brand\":\"Xiaomi\",\"model\":\"
          "condition":["servicedata", 12, "10"],
          "decoder":["value_from_hex_data", "servicedata", 14, 2, false, false]
       },
-      "opening":{
+      "open":{
          "condition":["servicedata", 16, "11"],
          "decoder":["value_from_hex_data", "servicedata", 18, 2, false, false]
       }
@@ -166,7 +166,7 @@ const char* _LYWSD03MMC_BTHOME_1_json_props = "{\"properties\":{\"packet\":{\"un
    }
 })"""";*/
 
-const char* _LYWSD03MMC_BTHOME_2_json_props = "{\"properties\":{\"packet\":{\"unit\":\"int\",\"name\":\"packet id\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"},\"power\":{\"unit\":\"int\",\"name\":\"power\"},\"opening\":{\"unit\":\"int\",\"name\":\"opening\"}}}";
+const char* _LYWSD03MMC_BTHOME_2_json_props = "{\"properties\":{\"packet\":{\"unit\":\"int\",\"name\":\"packet id\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"},\"power\":{\"unit\":\"int\",\"name\":\"power\"},\"open\":{\"unit\":\"int\",\"name\":\"open\"}}}";
 /*R""""(
 {
    "properties":{
@@ -182,9 +182,9 @@ const char* _LYWSD03MMC_BTHOME_2_json_props = "{\"properties\":{\"packet\":{\"un
          "unit": "int",
          "name": "power"
       },
-      "opening": {
+      "open": {
          "unit": "int",
-         "name": "opening"
+         "name": "open"
       }
    }
 })"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -371,10 +371,10 @@ const char* expected_uuid_name_svcdata[] = {
     "{\"brand\":\"Sensor Easy\",\"model\":\"SE MAG\",\"model_id\":\"SE_MAG\",\"type\":\"CTMO\",\"open\":false,\"cont\":true}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Outdoor Meter\",\"model_id\":\"W340001X\",\"type\":\"THB\",\"batt\":65}",
     "{\"brand\":\"Tuya\",\"model\":\"THB1 Thermo-Hygrometer\",\"model_id\":\"THB1\",\"type\":\"THB\",\"acts\":true,\"packet\":239,\"tempc\":17.94,\"tempf\":64.292,\"hum\":60.72,\"batt\":74,\"volt\":2.748}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"acts\":true,\"cont\":true,\"packet\":132,\"tempc\":20.79,\"tempf\":69.422,\"hum\":71.88,\"batt\":100}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"acts\":true,\"cont\":true,\"packet\":129,\"volt\":3.034,\"power\":1,\"opening\":1}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"acts\":true,\"cont\":true,\"encr\":2,\"cipher\":\"be07860de133b342\",\"ctr\":\"23020000\",\"mic\":\"50dea27d\"}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"acts\":true,\"cont\":true,\"encr\":2,\"cipher\":\"613c80e969f052\",\"ctr\":\"a9000000\",\"mic\":\"77b39384\"}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"cont\":true,\"packet\":132,\"tempc\":20.79,\"tempf\":69.422,\"hum\":71.88,\"batt\":100}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"cont\":true,\"packet\":129,\"volt\":3.034,\"power\":1,\"opening\":1}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"cont\":true,\"encr\":2,\"cipher\":\"be07860de133b342\",\"ctr\":\"23020000\",\"mic\":\"50dea27d\"}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"cont\":true,\"encr\":2,\"cipher\":\"613c80e969f052\",\"ctr\":\"a9000000\",\"mic\":\"77b39384\"}",
 };
 
 const char* expected_uuid[] = {

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -371,10 +371,10 @@ const char* expected_uuid_name_svcdata[] = {
     "{\"brand\":\"Sensor Easy\",\"model\":\"SE MAG\",\"model_id\":\"SE_MAG\",\"type\":\"CTMO\",\"open\":false,\"cont\":true}",
     "{\"brand\":\"SwitchBot\",\"model\":\"Outdoor Meter\",\"model_id\":\"W340001X\",\"type\":\"THB\",\"batt\":65}",
     "{\"brand\":\"Tuya\",\"model\":\"THB1 Thermo-Hygrometer\",\"model_id\":\"THB1\",\"type\":\"THB\",\"acts\":true,\"packet\":239,\"tempc\":17.94,\"tempf\":64.292,\"hum\":60.72,\"batt\":74,\"volt\":2.748}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"acts\":true,\"packet\":132,\"tempc\":20.79,\"tempf\":69.422,\"hum\":71.88,\"batt\":100}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"acts\":true,\"packet\":129,\"volt\":3.034,\"power\":1,\"opening\":1}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"acts\":true,\"encr\":2,\"cipher\":\"be07860de133b342\",\"ctr\":\"23020000\",\"mic\":\"50dea27d\"}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"acts\":true,\"encr\":2,\"cipher\":\"613c80e969f052\",\"ctr\":\"a9000000\",\"mic\":\"77b39384\"}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"acts\":true,\"cont\":true,\"packet\":132,\"tempc\":20.79,\"tempf\":69.422,\"hum\":71.88,\"batt\":100}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"acts\":true,\"cont\":true,\"packet\":129,\"volt\":3.034,\"power\":1,\"opening\":1}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"acts\":true,\"cont\":true,\"encr\":2,\"cipher\":\"be07860de133b342\",\"ctr\":\"23020000\",\"mic\":\"50dea27d\"}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"acts\":true,\"cont\":true,\"encr\":2,\"cipher\":\"613c80e969f052\",\"ctr\":\"a9000000\",\"mic\":\"77b39384\"}",
 };
 
 const char* expected_uuid[] = {

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -372,7 +372,7 @@ const char* expected_uuid_name_svcdata[] = {
     "{\"brand\":\"SwitchBot\",\"model\":\"Outdoor Meter\",\"model_id\":\"W340001X\",\"type\":\"THB\",\"batt\":65}",
     "{\"brand\":\"Tuya\",\"model\":\"THB1 Thermo-Hygrometer\",\"model_id\":\"THB1\",\"type\":\"THB\",\"acts\":true,\"packet\":239,\"tempc\":17.94,\"tempf\":64.292,\"hum\":60.72,\"batt\":74,\"volt\":2.748}",
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"cont\":true,\"packet\":132,\"tempc\":20.79,\"tempf\":69.422,\"hum\":71.88,\"batt\":100}",
-    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"cont\":true,\"packet\":129,\"volt\":3.034,\"power\":1,\"opening\":1}",
+    "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME\",\"type\":\"THB\",\"cont\":true,\"packet\":129,\"volt\":3.034,\"power\":1,\"open\":1}",
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"cont\":true,\"encr\":2,\"cipher\":\"be07860de133b342\",\"ctr\":\"23020000\",\"mic\":\"50dea27d\"}",
     "{\"brand\":\"Xiaomi\",\"model\":\"TH Sensor\",\"model_id\":\"LYWSD03MMC/MJWSD05MMC_PVVX_BTHOME_ENCR\",\"type\":\"THB\",\"cont\":true,\"encr\":2,\"cipher\":\"613c80e969f052\",\"ctr\":\"a9000000\",\"mic\":\"77b39384\"}",
 };


### PR DESCRIPTION
## Description:

The LYWSD03MMC sensors when running PVVX and BTHome beacons creates two separate frames `LYWSD03MMC_json_PVVX_BTHOME_1` and `LYWSD03MMC_json_PVVX_BTHOME_2` when using OpenMQTTGateway the devices should be configured as continuous scanning and not active scanning as the frames alternate between `BTHOME_1` and `BTHOME_2` sent every 2500ms as per the screenshot below from the PVVX Telink Flasher for Mi Thermostat. What happens is OpenMQTTGateway sometimes sees one frame or the other and creates entitles in Home Assistant as one or the other. When this is swapped over to continuous scanning and Adaptive scan is enabled in OpenMQTTGateway then all the values are correctly created in Home Assistant via OpenMQTTGateway.

<img width="521" height="86" alt="image" src="https://github.com/user-attachments/assets/f4e2dc88-583b-48a1-bf30-8cf4e9aab17e" />

This only applies to the BTHome beacons as the PVVX and ATC beacons is only a single frame.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
