### PR TITLE
feat: Initial support for IBS-P02B

### DIFF
--- a/docs/devices/IBS-P02B.md
+++ b/docs/devices/IBS-P02B.md
@@ -1,0 +1,12 @@
+# Inkbird P02B
+
+|Model Id|[IBS-P02B](https://github.com/theengs/decoder/blob/development/src/devices/IBS_P02B_json.h)|
+|-|-|
+|Brand|Inkbird|
+|Model|Pool Thermometer|
+|Short Description|Pool temperature sensor IPX7|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power Source|2 AAA|
+|Exchanged Data|temperature, battery, lowBat|
+|Encrypted|No|

--- a/docs/devices/IBS-P02B.md
+++ b/docs/devices/IBS-P02B.md
@@ -10,3 +10,5 @@
 |Power Source|2 AAA|
 |Exchanged Data|temperature, battery, lowBat|
 |Encrypted|No|
+
+Note: the device will not broadcast BLE data when connected to the Inkbird app.

--- a/docs/devices/IBS-P02B.md
+++ b/docs/devices/IBS-P02B.md
@@ -8,7 +8,7 @@
 |Communication|BLE broadcast|
 |Frequency|2.4Ghz|
 |Power Source|2 AAA|
-|Exchanged Data|temperature, battery, lowBat|
+|Exchanged Data|temperature, battery, lowBat, displayUnit|
 |Encrypted|No|
 
 Note: the device will not broadcast BLE data when connected to the Inkbird app.

--- a/docs/devices/IBS-P02B.md
+++ b/docs/devices/IBS-P02B.md
@@ -8,7 +8,7 @@
 |Communication|BLE broadcast|
 |Frequency|2.4Ghz|
 |Power Source|2 AAA|
-|Exchanged Data|temperature, battery, lowBat, displayUnit|
+|Exchanged Data|tempc, batt, lowbatt, displayunit|
 |Encrypted|No|
 
 Note: the device will not broadcast BLE data when connected to the Inkbird app.

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -63,6 +63,7 @@ public:
     CGDK2_ATC1441,
     CGH1,
     JQJCY01YM,
+    IBS_P02B,
     IBSTHBP01B,
     IBT_2X,
     IBT_2XS,

--- a/src/devices.h
+++ b/src/devices.h
@@ -41,6 +41,7 @@
 #include "devices/HHCCJCY01HHCC_json.h"
 #include "devices/HHCCPOT002_json.h"
 #include "devices/HOBOMX2001_json.h"
+#include "devices/IBS_P02B_json.h"
 #include "devices/IBS_THBP01B_json.h"
 #include "devices/IBT_2X_json.h"
 #include "devices/IBT_4XS_json.h"
@@ -157,6 +158,7 @@ const char* _devices[][2] = {
     {_CGDK2_json_ATC1441, _CGDK2_json_props},
     {_CGH1_json, _CGH1_json_props},
     {_JQJCY01YM_json, _JQJCY01YM_json_props},
+    {_IBS_P02B_json, _IBS_P02B_json_props},
     {_IBS_THBP01B_json, _IBS_THBP01B_json_props},
     {_IBT_2X_json_2X, _IBT_2X_json_props},
     {_IBT_2X_json_2XS, _IBT_2X_json_props},

--- a/src/devices/IBS_P02B_json.h
+++ b/src/devices/IBS_P02B_json.h
@@ -1,4 +1,4 @@
-const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowBat\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,\"false\",\"true\"]}}}";
+const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowBat\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,\"false\",\"true\"]},\"displayUnit\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",23,0,\"C\",\"F\"]}}}";
 /*R""""(
 {
   "brand":"Inkbird",
@@ -16,11 +16,14 @@ const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermomete
    },
    "lowBat":{
       "decoder":["bit_static_value", "manufacturerdata", 26, 0, "false", "true"]
+   },
+   "displayUnit":{
+      "decoder":["bit_static_value", "manufacturerdata", 23, 0, "C", "F"]
    }
   }
 })"""";*/
 
-const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lowBat\":{\"unit\":\"string\",\"name\":\"lowBat\"}}}";
+const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lowBat\":{\"unit\":\"string\",\"name\":\"lowBat\"},\"displayUnit\":{\"unit\":\"string\",\"name\":\"displayUnit\"}}}";
 /*R""""(
 {
    "properties":{
@@ -35,6 +38,10 @@ const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\"
       "lowBat":{
          "unit":"string",
          "name":"lowBat"
+      },
+      "displayUnit":{
+         "unit":"string",
+         "name":"displayUnit"
       }
    }
 })"""";*/

--- a/src/devices/IBS_P02B_json.h
+++ b/src/devices/IBS_P02B_json.h
@@ -1,4 +1,4 @@
-const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowBat\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,\"false\",\"true\"]},\"displayUnit\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",23,0,\"C\",\"F\"]}}}";
+const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowbatt\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,false,true]},\"displayunit\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",23,0,\"C°\",\"F°\"]}}}";
 /*R""""(
 {
   "brand":"Inkbird",
@@ -14,16 +14,16 @@ const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermomete
    "batt":{
       "decoder":["value_from_hex_data", "manufacturerdata", 20, 2]
    },
-   "lowBat":{
-      "decoder":["bit_static_value", "manufacturerdata", 26, 0, "false", "true"]
+   "lowbatt":{
+      "decoder":["bit_static_value", "manufacturerdata", 26, 0, false, true]
    },
-   "displayUnit":{
-      "decoder":["bit_static_value", "manufacturerdata", 23, 0, "C", "F"]
+   "displayunit":{
+      "decoder":["bit_static_value", "manufacturerdata", 23, 0, "C°", "F°"]
    }
   }
 })"""";*/
 
-const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lowBat\":{\"unit\":\"string\",\"name\":\"lowBat\"},\"displayUnit\":{\"unit\":\"string\",\"name\":\"displayUnit\"}}}";
+const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lowbatt\":{\"unit\":\"status\",\"name\":\"lowbatt\"},\"displayunit\":{\"unit\":\"string\",\"name\":\"displayUnit\"}}}";
 /*R""""(
 {
    "properties":{
@@ -35,11 +35,11 @@ const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\"
          "unit":"%",
          "name":"battery"
       },
-      "lowBat":{
-         "unit":"string",
-         "name":"lowBat"
+      "lowbatt":{
+         "unit":"status",
+         "name":"lowbatt"
       },
-      "displayUnit":{
+      "displayunit":{
          "unit":"string",
          "name":"displayUnit"
       }

--- a/src/devices/IBS_P02B_json.h
+++ b/src/devices/IBS_P02B_json.h
@@ -1,4 +1,4 @@
-const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",13,4,true],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowBat\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,\"false\",\"true\"]}}}";
+const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowBat\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,\"false\",\"true\"]}}}";
 /*R""""(
 {
   "brand":"Inkbird",
@@ -8,7 +8,7 @@ const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermomete
   "condition":["name", "index", 0, "IBS-P02B", "&", "manufacturerdata", "=", 36],
   "properties":{
     "tempc":{
-      "decoder":["value_from_hex_data","manufacturerdata", 13, 4, true],
+      "decoder":["value_from_hex_data","manufacturerdata", 12, 2, true, false],
       "post_proc":["/",10]
     },
    "batt":{

--- a/src/devices/IBS_P02B_json.h
+++ b/src/devices/IBS_P02B_json.h
@@ -1,0 +1,34 @@
+const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"IBS-P02B\",\"model_id\":\"IBS-P02B\",\"type\":\"THERM\",\"cidc\":false,\"condition\":[\"name\",\"contain\",\"IBS-P02B\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",13,4,true],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",21,2]}}}";
+/*R""""(
+{
+  "brand":"Inkbird",
+  "model":"IBS-P02B",
+  "model_id":"IBS-P02B",
+  "type":"THERM",
+  "cidc":false,
+  "condition":["name","contain","IBS-P02B"],
+  "properties":{
+    "tempc":{
+      "decoder":["value_from_hex_data","manufacturerdata", 13, 4, true],
+      "post_proc":["/",10]
+    },
+   "batt":{
+      "decoder":["value_from_hex_data", "manufacturerdata", 21, 2]
+   }
+  }
+})"""";*/
+
+const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"}}}";
+/*R""""(
+{
+   "properties":{
+      "tempc":{
+         "unit":"°C",
+         "name":"temperature"
+      },
+      "batt":{
+         "unit":"%",
+         "name":"battery"
+      }
+   }
+})"""";*/

--- a/src/devices/IBS_P02B_json.h
+++ b/src/devices/IBS_P02B_json.h
@@ -1,24 +1,26 @@
-const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"IBS-P02B\",\"model_id\":\"IBS-P02B\",\"type\":\"THERM\",\"cidc\":false,\"condition\":[\"name\",\"contain\",\"IBS-P02B\"],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",13,4,true],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",21,2]}}}";
+const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",13,4,true],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowBat\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,\"false\",\"true\"]}}}";
 /*R""""(
 {
   "brand":"Inkbird",
-  "model":"IBS-P02B",
+  "model":"Pool Thermometer",
   "model_id":"IBS-P02B",
-  "type":"THERM",
-  "cidc":false,
-  "condition":["name","contain","IBS-P02B"],
+  "tag": "0103",
+  "condition":["name", "index", 0, "IBS-P02B", "&", "manufacturerdata", "=", 36],
   "properties":{
     "tempc":{
       "decoder":["value_from_hex_data","manufacturerdata", 13, 4, true],
       "post_proc":["/",10]
     },
    "batt":{
-      "decoder":["value_from_hex_data", "manufacturerdata", 21, 2]
+      "decoder":["value_from_hex_data", "manufacturerdata", 20, 2]
+   },
+   "lowBat":{
+      "decoder":["bit_static_value", "manufacturerdata", 26, 0, "false", "true"]
    }
   }
 })"""";*/
 
-const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"}}}";
+const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lowBat\":{\"unit\":\"string\",\"name\":\"lowBat\"}}}";
 /*R""""(
 {
    "properties":{
@@ -29,6 +31,10 @@ const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\"
       "batt":{
          "unit":"%",
          "name":"battery"
+      },
+      "lowBat":{
+         "unit":"string",
+         "name":"lowBat"
       }
    }
 })"""";*/

--- a/src/devices/IBS_P02B_json.h
+++ b/src/devices/IBS_P02B_json.h
@@ -23,7 +23,7 @@ const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermomete
   }
 })"""";*/
 
-const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lowbatt\":{\"unit\":\"status\",\"name\":\"lowbatt\"},\"displayunit\":{\"unit\":\"string\",\"name\":\"displayUnit\"}}}";
+const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"lowbatt\":{\"unit\":\"status\",\"name\":\"battery\"},\"displayunit\":{\"unit\":\"string\",\"name\":\"displayUnit\"}}}";
 /*R""""(
 {
    "properties":{
@@ -37,7 +37,7 @@ const char* _IBS_P02B_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\"
       },
       "lowbatt":{
          "unit":"status",
-         "name":"lowbatt"
+         "name":"battery"
       },
       "displayunit":{
          "unit":"string",

--- a/src/devices/IBS_P02B_json.h
+++ b/src/devices/IBS_P02B_json.h
@@ -1,4 +1,4 @@
-const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowbatt\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,false,true]},\"displayunit\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",23,0,\"C°\",\"F°\"]}}}";
+const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermometer\",\"model_id\":\"IBS-P02B\",\"tag\":\"0103\",\"condition\":[\"name\",\"index\",0,\"IBS-P02B\",\"&\",\"manufacturerdata\",\"=\",36],\"properties\":{\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,true,false],\"post_proc\":[\"/\",10]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",20,2]},\"lowbatt\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",26,0,false,true]},\"displayunit\":{\"decoder\":[\"bit_static_value\",\"manufacturerdata\",23,0,\"°C\",\"°F\"]}}}";
 /*R""""(
 {
   "brand":"Inkbird",
@@ -18,7 +18,7 @@ const char* _IBS_P02B_json = "{\"brand\":\"Inkbird\",\"model\":\"Pool Thermomete
       "decoder":["bit_static_value", "manufacturerdata", 26, 0, false, true]
    },
    "displayunit":{
-      "decoder":["bit_static_value", "manufacturerdata", 23, 0, "C°", "F°"]
+      "decoder":["bit_static_value", "manufacturerdata", 23, 0, "°C", "°F"]
    }
   }
 })"""";*/


### PR DESCRIPTION
Adding support for Inkbird IBS-P02B pool thermometer

I have the temperature working, but have been struggling with the battery level and would love some help. Following is a sample of data reported by the ScanAndDecode script.

```
data sent to decoder:  {"manufacturerdata": "49250327059dde0000005901800000000000", "name": "IBS-P02B", "id": "49:25:03:27:05:9D", "rssi": -59}
TheengsDecoder found device: {"manufacturerdata":"49250327059dde0000005901800000000000","name":"IBS-P02B","id":"49:25:03:27:05:9D","rssi":-59,"brand":"Inkbird","model":"IBS-P02B","model_id":"IBS-P02B","tempc":22.4,"tempf":72.32,"batt":-112}
{"properties":{"tempc":{"unit":"°C","name":"temperature"},"batt":{"unit":"%","name":"battery"}}}
brand: Inkbird , model: IBS-P02B
```

Here are some sample payloads with differing voltages.
| voltage | payload |
| :--- | :--- |
| 3.0v+ | 49250327059dde0000006401800000000000 |
| 2.62v | 49250327059dde0000003401800000000000 |
| 2.22v | 49250327059dde0000000201801000000000 |

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).