### PR TITLE
Feature/broodminder w

### DIFF
--- a/docs/devices/BRM.md
+++ b/docs/devices/BRM.md
@@ -1,0 +1,12 @@
+# BroodMinder - Hive Monitoring Sensors
+
+|Model Id|[BRM-41,BRM-42,BRM-43, BRM-47,BRM-49,BRM-56, BRM-57, BRM-58](https://github.com/theengs/decoder/blob/development/src/devices/BRM_json.h)|
+|-|-|
+|Brand|BroodMinder|
+|Model|W,W3,W5,XLR,TH,TH2,TH3,T|
+|Short Description|Hive Scale and TH Sensors|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power Source|CR2032,AA|
+|Exchanged Data|weight, temperature, humidity, battery|
+|Encrypted|No|

--- a/src/devices.h
+++ b/src/devices.h
@@ -106,6 +106,7 @@
 #include "devices/BWBSDOO_json.h"
 #include "devices/BM2_json.h"
 #include "devices/BM6_json.h"
+#include "devices/BRM_json.h"
 #include "devices/TILT_json.h"
 #include "devices/JAALEE_json.h"
 #include "devices/APPLEAIRPODS_json.h"
@@ -226,6 +227,14 @@ const char* _devices[][2] = {
     {_BWBSDOO_json, _BWBSDOO_json_props},
     {_BM2_json, _BM2_json_props},
     {_BM6_json, _BM6_json_props},
+    {_BRM_json_W, _BRM_json_props},
+    {_BRM_json_W3, _BRM_json_props},
+    {_BRM_json_W5, _BRM_json_props},
+    {_BRM_json_XLR, _BRM_json_props},
+    {_BRM_json_TH, _BRM_json_props},
+    {_BRM_json_TH2, _BRM_json_props},
+    {_BRM_json_T, _BRM_json_props},
+    {_BRM_json_TH3, _BRM_json_props},
     {_TILT_json, _TILT_json_props},
     {_RDL52832_json, _RDL52832_json_props},
     {_ABN03_json, _ABN03_json_props},

--- a/src/devices/BRM_json.h
+++ b/src/devices/BRM_json.h
@@ -1,0 +1,373 @@
+// Based on product doc https://doc.mybroodminder.com/87_physics_and_tech_stuff/
+// Hive scale support: _BRM_json_W, BRMW_json_W3, _BRM_json_W5, _BRM_json_XLR 
+// Temp support: _BRM_json_TH, _BRM_json_TH2, _BRM_json_T, _BRMW_json_TH3
+const char* _BRM_json_W = "{\"brand\":\"BroodMinder\",\"model\":\"W Half-Hive Scale\",\"model_id\":\"BRM-43\",\"tag\":\"0500\",\"condition\":[\"manufacturerdata\",\"=\",46,\"index\",0,\"8d02\",\"&\",\"manufacturerdata\",\"index\",4,\"2B\"],\"properties\":{\"version\":{\"decoder\":[\"bf_value_from_hex_data\",\"manufacturerdata\",6,4,true]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,false,false]},\"sample\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,true,true]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,true,true],\"post_proc\":[\"/\",10813400]},\".cal\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",22,2,false,true],\"post_proc\":[\"<\",\"8\"]},\"temp_rt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,true],\"post_proc\":[\"+\",\".cal\",\"-\",5000,\"/\",100]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,2,false,true]},\"wt_t\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",42,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_l\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_r\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]}}}";
+
+/*R""""(
+{
+  "brand":"BroodMinder",
+  "model":"W Half-Hive Scale",
+  "model_id":"BRM-43",
+  "tag":"0500",  
+  "condition":["manufacturerdata","=",46,"index",0,"8d02","&","manufacturerdata","index",4,"2B"],
+  "properties":{
+     "version":{
+       "decoder":["bf_value_from_hex_data","manufacturerdata",6,4,true]
+     }  ,   
+     "batt":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",12,2,false,false]
+      },
+     "sample":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",14,4,true,true]
+      },
+     "tempc":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",18,4,true,true],
+       "post_proc":["/",10813400]
+      },
+     ".cal":{
+       "decoder":["value_from_hex_data","manufacturerdata",22,2,false,true],
+       "post_proc":["<","8"]
+     }, 
+     "temp_rt":{
+       "decoder":["value_from_hex_data","manufacturerdata",10,2,false,true],
+       "post_proc":["+",".cal","-",5000,"/",100]
+     },
+     "hum":{
+       "decoder":["value_from_hex_data","manufacturerdata",32,2,false,true]
+      },
+     "wt_t":{  
+       "decoder":["value_from_hex_data","manufacturerdata",42,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_l":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",24,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_r":{   
+       "decoder":["value_from_hex_data","manufacturerdata",28,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      } 
+  }
+})"""";*/
+
+const char* _BRM_json_W3 = "{\"brand\":\"BroodMinder\",\"model\":\"W3/W4 Full Hive Scale\",\"model_id\":\"BRM-49\",\"tag\":\"0500\",\"condition\":[\"manufacturerdata\",\"=\",46,\"index\",0,\"8d02\",\"&\",\"manufacturerdata\",\"index\",4,\"31\"],\"properties\":{\"version\":{\"decoder\":[\"bf_value_from_hex_data\",\"manufacturerdata\",6,4,true]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,false,false]},\"sample\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,true,true]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,true,true],\"post_proc\":[\"-\",5000,\"/\",100]},\".cal\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",22,2,false,true],\"post_proc\":[\"<\",\"8\"]},\"temp_rt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,true],\"post_proc\":[\"+\",\".cal\",\"-\",5000,\"/\",100]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,2,false,true]},\"wt_t\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",42,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_l\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_r\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_l2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",34,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_r2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",38,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]}}}";
+/*R""""(
+{
+  "brand":"BroodMinder",
+  "model":"W3/W4 Full Hive Scale",
+  "model_id":"BRM-49",
+  "tag":"0500",  
+  "condition":["manufacturerdata","=",46,"index",0,"8d02","&","manufacturerdata","index",4,"31"],
+  "properties":{
+     "version":{
+       "decoder":["bf_value_from_hex_data","manufacturerdata",6,4,true]
+     }  ,   
+     "batt":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",12,2,false,false]
+      },
+     "sample":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",14,4,true,true]
+      },
+     "tempc":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",18,4,true,true],
+       "post_proc":["-",5000,"/",100]
+      },
+     ".cal":{
+       "decoder":["value_from_hex_data","manufacturerdata",22,2,false,true],
+       "post_proc":["<","8"]
+     }, 
+     "temp_rt":{
+       "decoder":["value_from_hex_data","manufacturerdata",10,2,false,true],
+       "post_proc":["+",".cal","-",5000,"/",100]
+     },
+     "hum":{
+       "decoder":["value_from_hex_data","manufacturerdata",32,2,false,true]
+      },
+     "wt_t":{  
+       "decoder":["value_from_hex_data","manufacturerdata",42,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_l":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",24,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_r":{   
+       "decoder":["value_from_hex_data","manufacturerdata",28,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_l2":{
+       "decoder":["value_from_hex_data","manufacturerdata",34,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_r2":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",38,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      }       
+  }
+})"""";*/
+
+const char* _BRM_json_W5 = "{\"brand\":\"BroodMinder\",\"model\":\"W5 Full-Hive Scale\",\"model_id\":\"BRM-57\",\"tag\":\"0500\",\"condition\":[\"manufacturerdata\",\"=\",46,\"index\",0,\"8d02\",\"&\",\"manufacturerdata\",\"index\",4,\"39\"],\"properties\":{\"version\":{\"decoder\":[\"bf_value_from_hex_data\",\"manufacturerdata\",6,4,true]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,false,false]},\"sample\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,true,true]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,true,true],\"post_proc\":[\"-\",5000,\"/\",100]},\".cal\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",22,2,false,true],\"post_proc\":[\"<\",\"8\"]},\"temp_rt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,true],\"post_proc\":[\"+\",\".cal\",\"-\",5000,\"/\",100]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,2,false,true]},\"wt_t\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",42,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_l\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_r\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]}}}";
+/*R""""(
+{
+  "brand":"BroodMinder",
+  "model":"W5 Full-Hive Scale",
+  "model_id":"BRM-57",
+  "tag":"0500",  
+  "condition":["manufacturerdata","=",46,"index",0,"8d02","&","manufacturerdata","index",4,"39"],
+  "properties":{
+     "version":{
+       "decoder":["bf_value_from_hex_data","manufacturerdata",6,4,true]
+     }  ,   
+     "batt":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",12,2,false,false]
+      },
+     "sample":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",14,4,true,true]
+      },
+     "tempc":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",18,4,true,true],
+       "post_proc":["-",5000,"/",100]
+      },
+     ".cal":{
+       "decoder":["value_from_hex_data","manufacturerdata",22,2,false,true],
+       "post_proc":["<","8"]
+     }, 
+     "temp_rt":{
+       "decoder":["value_from_hex_data","manufacturerdata",10,2,false,true],
+       "post_proc":["+",".cal","-",5000,"/",100]
+     },
+     "hum":{
+       "decoder":["value_from_hex_data","manufacturerdata",32,2,false,true]
+      },
+     "wt_t":{  
+       "decoder":["value_from_hex_data","manufacturerdata",42,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_l":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",24,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_r":{   
+       "decoder":["value_from_hex_data","manufacturerdata",28,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      } 
+  }
+})"""";*/
+
+const char* _BRM_json_XLR = "{\"brand\":\"BroodMinder\",\"model\":\"XLR Board\",\"model_id\":\"BRM-58\",\"tag\":\"0500\",\"condition\":[\"manufacturerdata\",\"=\",46,\"index\",0,\"8d02\",\"&\",\"manufacturerdata\",\"index\",4,\"3a\"],\"properties\":{\"version\":{\"decoder\":[\"bf_value_from_hex_data\",\"manufacturerdata\",6,4,true]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,false,false]},\"sample\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,true,true]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,true,true],\"post_proc\":[\"-\",5000,\"/\",100]},\".cal\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",22,2,false,true],\"post_proc\":[\"<\",\"8\"]},\"temp_rt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",10,2,false,true],\"post_proc\":[\"+\",\".cal\",\"-\",5000,\"/\",100]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,2,false,true]},\"wt_t\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",42,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_l\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",24,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_r\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",28,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_l2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",34,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]},\"wt_r2\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",38,4,true,false],\"post_proc\":[\"-\",32767,\"/\",100]}}}";
+/*R""""(
+{
+  "brand":"BroodMinder",
+  "model":"XLR Board",
+  "model_id":"BRM-58",
+  "tag":"0500",  
+  "condition":["manufacturerdata","=",46,"index",0,"8d02","&","manufacturerdata","index",4,"3a"],
+  "properties":{
+     "version":{
+       "decoder":["bf_value_from_hex_data","manufacturerdata",6,4,true]
+     }  ,   
+     "batt":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",12,2,false,false]
+      },
+     "sample":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",14,4,true,true]
+      },
+     "tempc":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",18,4,true,true],
+       "post_proc":["-",5000,"/",100]
+      },
+     ".cal":{
+       "decoder":["value_from_hex_data","manufacturerdata",22,2,false,true],
+       "post_proc":["<","8"]
+     }, 
+     "temp_rt":{
+       "decoder":["value_from_hex_data","manufacturerdata",10,2,false,true],
+       "post_proc":["+",".cal","-",5000,"/",100]
+     },
+     "hum":{
+       "decoder":["value_from_hex_data","manufacturerdata",32,2,false,true]
+      },
+     "wt_t":{  
+       "decoder":["value_from_hex_data","manufacturerdata",42,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_l":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",24,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_r":{   
+       "decoder":["value_from_hex_data","manufacturerdata",28,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_l2":{
+       "decoder":["value_from_hex_data","manufacturerdata",34,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      },
+     "wt_r2":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",38,4,true,false],
+       "post_proc":["-",32767,"/",100]
+      }       
+  }
+})"""";*/
+
+const char* _BRM_json_TH = "{\"brand\":\"BroodMinder\",\"model\":\"T/H\",\"model_id\":\"BRM-41\",\"tag\":\"0200\",\"condition\":[\"manufacturerdata\",\"=\",46,\"index\",0,\"8d02\",\"&\",\"manufacturerdata\",\"index\",4,\"29\"],\"properties\":{\"version\":{\"decoder\":[\"bf_value_from_hex_data\",\"manufacturerdata\",6,4,true]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,false,false]},\"sample\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,true,true]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,true,true],\"post_proc\":[\"/\",10813400]}}}";
+/*R""""(
+{
+  "brand":"BroodMinder",
+  "model":"T/H",
+  "model_id":"BRM-41",
+  "tag":"0200",  
+  "condition":["manufacturerdata","=",46,"index",0,"8d02","&","manufacturerdata","index",4,"29"],
+  "properties":{
+     "version":{
+       "decoder":["bf_value_from_hex_data","manufacturerdata",6,4,true]
+     }  ,   
+     "batt":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",12,2,false,false]
+      },
+     "sample":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",14,4,true,true]
+      },
+     "tempc":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",18,4,true,true],
+       "post_proc":["/",10813400]
+      }
+  }
+})"""";*/
+
+const char* _BRM_json_TH2 = "{\"brand\":\"BroodMinder\",\"model\":\"TH2\",\"model_id\":\"BRM-42\",\"tag\":\"0200\",\"condition\":[\"manufacturerdata\",\"=\",46,\"index\",0,\"8d02\",\"&\",\"manufacturerdata\",\"index\",4,\"2a\"],\"properties\":{\"version\":{\"decoder\":[\"bf_value_from_hex_data\",\"manufacturerdata\",6,4,true]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,false,false]},\"sample\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,true,true]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,true,true],\"post_proc\":[\"/\",10813400]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,2,false,true]}}}";
+/*R""""(
+{
+  "brand":"BroodMinder",
+  "model":"TH2",
+  "model_id":"BRM-42",
+  "tag":"0200",  
+  "condition":["manufacturerdata","=",46,"index",0,"8d02","&","manufacturerdata","index",4,"2a"],
+  "properties":{
+     "version":{
+       "decoder":["bf_value_from_hex_data","manufacturerdata",6,4,true]
+     }  ,   
+     "batt":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",12,2,false,false]
+      },
+     "sample":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",14,4,true,true]
+      },
+     "tempc":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",18,4,true,true],
+       "post_proc":["/",10813400]
+      },
+     "hum":{
+       "decoder":["value_from_hex_data","manufacturerdata",32,2,false,true]
+      }
+  }
+})"""";*/
+
+const char* _BRM_json_T = "{\"brand\":\"BroodMinder\",\"model\":\"T,T2,T3,SM\",\"model_id\":\"BRM-47\",\"tag\":\"0200\",\"condition\":[\"manufacturerdata\",\"=\",46,\"index\",0,\"8d02\",\"&\",\"manufacturerdata\",\"index\",4,\"2f\"],\"properties\":{\"version\":{\"decoder\":[\"bf_value_from_hex_data\",\"manufacturerdata\",6,4,true]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,false,false]},\"sample\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,true,true]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,true,true],\"post_proc\":[\"+\",\".cal\",\"-\",5000,\"/\",100]}}}";
+/*R""""(
+{
+  "brand":"BroodMinder",
+  "model":"T,T2,T3,SM",
+  "model_id":"BRM-47",
+  "tag":"0200",  
+  "condition":["manufacturerdata","=",46,"index",0,"8d02","&","manufacturerdata","index",4,"2f"],
+  "properties":{
+     "version":{
+       "decoder":["bf_value_from_hex_data","manufacturerdata",6,4,true]
+     }  ,   
+     "batt":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",12,2,false,false]
+      },
+     "sample":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",14,4,true,true]
+      },
+     "tempc":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",18,4,true,true],
+       "post_proc":["+",".cal","-",5000,"/",100]
+      }
+  }
+})"""";*/
+
+const char* _BRM_json_TH3 = "{\"brand\":\"BroodMinder\",\"model\":\"TH3\",\"model_id\":\"BRM-56\",\"tag\":\"0200\",\"condition\":[\"manufacturerdata\",\"=\",46,\"index\",0,\"8d02\",\"&\",\"manufacturerdata\",\"index\",4,\"38\"],\"properties\":{\"version\":{\"decoder\":[\"bf_value_from_hex_data\",\"manufacturerdata\",6,4,true]},\"batt\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",12,2,false,false]},\"sample\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",14,4,true,true]},\"tempc\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",18,4,true,true],\"post_proc\":[\"+\",\".cal\",\"-\",5000,\"/\",100]},\"hum\":{\"decoder\":[\"value_from_hex_data\",\"manufacturerdata\",32,2,false,true]}}}";
+/*R""""(
+{
+  "brand":"BroodMinder",
+  "model":"TH3",
+  "model_id":"BRM-56",
+  "tag":"0200",  
+  "condition":["manufacturerdata","=",46,"index",0,"8d02","&","manufacturerdata","index",4,"38"],
+  "properties":{
+     "version":{
+       "decoder":["bf_value_from_hex_data","manufacturerdata",6,4,true]
+     }  ,   
+     "batt":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",12,2,false,false]
+      },
+     "sample":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",14,4,true,true]
+      },
+     "tempc":{ 
+       "decoder":["value_from_hex_data","manufacturerdata",18,4,true,true],
+       "post_proc":["+",".cal","-",5000,"/",100]
+      },
+     "hum":{
+       "decoder":["value_from_hex_data","manufacturerdata",32,2,false,true]
+      }
+  }
+})"""";*/
+
+const char* _BRM_json_props = "{\"properties\":{\"cfg\":{\"unit\":\"string\",\"name\":\"device type\"},\"version\":{\"unit\":\"float\",\"name\":\"firmware version\"},\"batt\":{\"unit\":\"%\",\"name\":\"battery\"},\"sample\":{\"unit\":\"int\",\"name\":\"sample count\"},\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"temp_rt\":{\"unit\":\"°C\",\"name\":\"reatime temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"wt_t\":{\"unit\":\"kg\",\"name\":\"weight-total\"},\"wt_l\":{\"unit\":\"kg\",\"name\":\"weight-left\"},\"wt_r\":{\"unit\":\"kg\",\"name\":\"weight-right\"},\"wt_l2\":{\"unit\":\"kg\",\"name\":\"weight-left-2\"},\"wt_r2\":{\"unit\":\"kg\",\"name\":\"weight-right-2\"}}}";
+/*R""""(
+{
+   "properties":{
+      "cfg":{
+        "unit":"string",
+        "name":"device type"
+        },
+      "version":{
+        "unit":"float",
+        "name":"firmware version"
+      },
+      "batt":{
+         "unit":"%",
+         "name":"battery"
+      },
+      "sample":{
+          "unit":"int",
+          "name":"sample count"
+      },
+      "tempc":{
+         "unit":"°C",
+         "name":"temperature"
+      },
+      "temp_rt": {
+         "unit":"°C",
+         "name":"reatime temperature"
+      },
+      "hum":{
+         "unit":"%",
+         "name":"humidity"
+      },
+      "wt_t":{
+          "unit":"kg",
+          "name":"weight-total"
+      },
+      "wt_l": {
+          "unit":"kg",
+          "name":"weight-left"
+      },
+      "wt_r": {
+          "unit":"kg",
+          "name":"weight-right"
+      }, 
+      "wt_l2": {
+          "unit":"kg",
+          "name":"weight-left-2"
+      },
+      "wt_r2": {
+          "unit":"kg",
+          "name":"weight-right-2"
+      }
+   }
+})"""";*/
+

--- a/tests/python_ble/decoder_test_BRM.py
+++ b/tests/python_ble/decoder_test_BRM.py
@@ -1,0 +1,26 @@
+from TheengsDecoder import decodeBLE as dble
+from TheengsDecoder import getProperties
+from TheengsDecoder import getAttribute
+import json
+
+test_cases = {
+    'Empty - fail': "",
+    "Blue Maestro - pass":
+      {"manufacturerdata": "330117630e10015c00a301ac00240100"},
+    "W5 - target":  
+      {"manufacturerdata": "8d02391604127d8b01721f20ba9cff7f2e00000000b59c", "name": "57:41:25", "id": "06:09:16:57:41:25", "rssi": -75},
+    "Short - fail":  
+      {"manufacturerdata": "8d02391604127d8b01721f20ba9cff7f2e000000b59c", "name": "57:41:25", "id": "06:09:16:57:41:25", "rssi": -75}
+}
+
+for scenario, message in test_cases.items():
+    print ("---", scenario)
+    print (json.dumps(message))
+    result = dble(json.dumps(message))
+    print ("result-->",result)
+    if result is not None:
+       parsed = json.loads(result)
+       model = parsed['model_id']
+       print(getProperties(model))
+       print("Brand =", getAttribute(model, 'brand'))
+       print("Model =", getAttribute(model, 'model'))


### PR DESCRIPTION
## Description:
Broodminder hive sensors promote a better understanding of honeybee hive properties over time, and is a useful tool for citizen science.   Useful sensor and device status data is available in the `manufacturerdata` payload.

I only have access to a W5 half-hive scale, and implemented decoders for the models below based on documentation and potentially outdated example code (for older models).  Appreciate updates from other real-world devices out there.

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Model ID | Hex | Model Name | Capability
-- | -- | -- | --
41 | 29 | T/H | Temperature, Humidity
42 | 2a | T/H (TH2) | Temperature, Humidity
43 | 2b | W (Half Hive Scale) | Half-hive Scale
47 | 2f | (TSM) T,T2,T3, SwarmMinder | Temperature, Swarm Detection
49 | 31 | W3, W4 Full Hive Scale | Full-hive Scale, Temperature, Humidity
56 | 38 | (THSM) TH3, SwarmMinder | Temperature, Humidity, Swarm Detection
57 | 39 | W5 (Half Hive Scale) | Half-hive Scale, Temperature, Humidity
58 | 3A | Scale-DIY Board | Full-hive Scale, Temperature, Humidity

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
