### PR TITLE
Added support to TH05F

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .cmake
 _skbuild
 dist
+/.idea/*

--- a/docs/devices/TH05F.md
+++ b/docs/devices/TH05F.md
@@ -1,0 +1,12 @@
+# Tuya TH05
+
+| Model Id          | [TH05F](https://github.com/theengs/decoder/blob/development/src/devices/TH05F_json.h) |
+|-------------------|---------------------------------------------------------------------------------------|
+| Brand             | Tuya                                                                                  |
+| Model             | TH05F Thermo-Hygrometer                                                               |
+| Short Description | Temperature and humidity sensor with PVVX firmware                                    |
+| Communication     | BLE broadcast                                                                         |
+| Frequency         | 2.4Ghz                                                                                |
+| Power Source      | CR2032                                                                                |
+| Exchanged Data    | temperature, humidity, battery, voltage                                               |
+| Encrypted         | No                                                                                    |

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -193,6 +193,7 @@ public:
     SBHT_003C,
     SBHT_003C_ENCR,
     VCH6003,
+    TH05F,
     BLE_ID_MAX
   };
 

--- a/src/devices.h
+++ b/src/devices.h
@@ -139,6 +139,7 @@
 #include "devices/SBHT_003C_json.h"
 #include "devices/SBHT_003C_ENCR_json.h"
 #include "devices/VCH6003_json.h"
+#include "devices/TH05F_json.h"
 
 
 const char* _devices[][2] = {
@@ -289,4 +290,5 @@ const char* _devices[][2] = {
     {_SBHT_003C_json, _SBHT_003C_json_props},
     {_SBHT_003C_ENCR_json, _SBHT_003C_ENCR_json_props},
     {_VCH6003_json, _VCH6003_json_props},
+    {_TH05F_json, _TH05F_json_props},
 };

--- a/src/devices/TH05F_json.h
+++ b/src/devices/TH05F_json.h
@@ -1,0 +1,49 @@
+// Decode information from Tuya TH05F (internal TH05Y - https://pvvx.github.io/TH05F/) running pvvx v2.1 firmware
+
+const char* _TH05F_json = "{\"brand\":\"Tuya\",\"model\":\"TH05F Thermo-Hygrometer\",\"model_id\":\"TH05F\",\"tag\":\"0102\",\"condition\":[\"uuid\",\"index\",0,\"fcd2\",\"&\",\"name\",\"contain\",\"TH05F\"],\"properties\":{\"packet\":{\"condition\":[\"servicedata\",2,\"00\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",4,2,false,false]},\"tempc\":{\"condition\":[\"servicedata\",10,\"02\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",12,4,true,true],\"post_proc\":[\"/\",100]},\"hum\":{\"condition\":[\"servicedata\",16,\"03\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",18,4,true,false],\"post_proc\":[\"/\",100]},\"batt\":{\"condition\":[\"servicedata\",6,\"01\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",8,2,false,false]},\"volt\":{\"condition\":[\"servicedata\",22,\"0c\"],\"decoder\":[\"value_from_hex_data\",\"servicedata\",24,4,true,false],\"post_proc\":[\"/\",1000]}}}";
+/*R""""(
+{
+  "brand": "Tuya",
+  "model": "TH05F Thermo-Hygrometer",
+  "model_id": "TH05F",
+  "tag": "0102",
+  "condition": ["uuid", "index", 0, "fcd2", "&","name", "contain", "TH05F"],
+   "properties":{
+      "packet":{
+         "condition":["servicedata", 2, "00"],
+         "decoder":["value_from_hex_data", "servicedata", 4, 2, false, false]
+      },
+      "tempc":{
+         "condition":["servicedata", 10, "02"],
+         "decoder":["value_from_hex_data", "servicedata", 12, 4, true, true],
+         "post_proc":["/", 100]
+      },
+      "hum":{
+         "condition":["servicedata", 16, "03"],
+         "decoder":["value_from_hex_data", "servicedata", 18, 4, true, false],
+         "post_proc":["/", 100]
+      },
+      "batt":{
+         "condition":["servicedata", 6, "01"],
+         "decoder":["value_from_hex_data", "servicedata", 8, 2, false, false]
+      },
+      "volt":{
+         "condition":["servicedata", 22, "0c"],
+         "decoder":["value_from_hex_data", "servicedata", 24, 4, true, false],
+         "post_proc":["/", 1000]
+      }
+  }
+}
+)"""";*/
+
+
+const char* _TH05F_json_props = "{\"properties\":{\"tempc\":{\"unit\":\"°C\",\"name\":\"temperature\"},\"hum\":{\"unit\":\"%\",\"name\":\"humidity\"},\"volt\":{\"unit\":\"V\",\"name\":\"voltage\"}}}";
+/*R""""(
+{
+  "properties": {
+    "tempc": { "unit": "°C", "name": "temperature" },
+    "hum":   { "unit": "%",  "name": "humidity" },
+    "volt":  { "unit": "V",  "name": "voltage" }
+  }
+}
+)"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -393,6 +393,7 @@ const char* expected_uuid_name_svcdata[] = {
     "{\"brand\":\"rbaron\",\"model\":\"b-parasite\",\"model_id\":\"BPv2.0\",\"type\":\"PLANT\",\"acts\":true,\"tempc\":26.55,\"tempf\":79.79,\"hum\":51,\"moi\":0,\"lux\":0,\"batt\":100,\"volt\":3.016}",
     "{\"brand\":\"rbaron\",\"model\":\"b-parasite\",\"model_id\":\"BPv2.0\",\"type\":\"PLANT\",\"acts\":true,\"tempc\":27.68,\"tempf\":81.824,\"hum\":73,\"moi\":66,\"lux\":0,\"batt\":100,\"volt\":3.016}",
     "{\"brand\":\"rbaron\",\"model\":\"b-parasite\",\"model_id\":\"BPv2.0\",\"type\":\"PLANT\",\"acts\":true,\"tempc\":30.36,\"tempf\":86.648,\"hum\":85,\"moi\":74,\"lux\":8392,\"batt\":100,\"volt\":3.005}",
+    "{\"brand\":\"Tuya\",\"model\":\"TH05F Thermo-Hygrometer\",\"model_id\":\"TH05F\",\"type\":\"THB\",\"acts\":true,\"packet\":163,\"tempc\":26.92,\"tempf\":80.456,\"hum\":67.06,\"batt\":81,\"volt\":2.814}",
 };
 
 const char* expected_uuid[] = {
@@ -1256,6 +1257,7 @@ const char* test_uuid_name_svcdata[][4] = {
     {"bParasiteV2", "0xfcd2", "prst", "400164025f0a050000000cc80b2e332f00"},
     {"bParasiteV2", "0xfcd2", "prst", "40016402d00a050000000cc80b2e492f42"},
     {"bParasiteV2", "0xfcd2", "prst", "40016402dc0b0520ce0c0cbd0b2e552f4a"},
+    {"TH05F PVVX", "0xfcd2", "TH05F-C451CC", "4000a3015102840a03321a0cfe0a"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{
@@ -1359,6 +1361,7 @@ TheengsDecoder::BLE_ID_NUM test_uuid_name_svcdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::BPARASITEV2,
     TheengsDecoder::BLE_ID_NUM::BPARASITEV2,
     TheengsDecoder::BLE_ID_NUM::BPARASITEV2,
+    TheengsDecoder::BLE_ID_NUM::TH05F,
 };
 
 // uuid test input [test name] [uuid] [data source] [data]

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -63,7 +63,7 @@ const char* expected_mfg[] = {
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":27.2,\"tempf\":80.96,\"hum\":71,\"batt_low\":false}",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":37.4,\"tempf\":99.32,\"hum\":74,\"batt_low\":false}",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":21.4,\"tempf\":70.52,\"hum\":67,\"batt_low\":false}",
-    "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":24.5,\"tempf\":76.1,\"hum\":50,\"batt_low\":false",
+    "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":24.5,\"tempf\":76.1,\"hum\":50,\"batt_low\":false}",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":24.6,\"tempf\":76.28,\"hum\":51,\"batt_low\":false}",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":25.5,\"tempf\":77.9,\"hum\":53,\"batt_low\":true}",
     "{\"brand\":\"ThermoPro\",\"model\":\"TH Sensor\",\"model_id\":\"TP35X/393\",\"type\":\"THB\",\"cidc\":false,\"acts\":true,\"tempc\":25.5,\"tempf\":77.9,\"hum\":53,\"batt_low\":true}",

--- a/tests/python_ble/README.MD
+++ b/tests/python_ble/README.MD
@@ -1,0 +1,4 @@
+# Run with:
+
+From root directory, 
+execute: `python -m unittest tests.python_ble.decoder_test`

--- a/tests/python_ble/decoder_test.py
+++ b/tests/python_ble/decoder_test.py
@@ -1,19 +1,19 @@
-from TheengsDecoder import decodeBLE as dble
-from TheengsDecoder import getProperties
-from TheengsDecoder import getAttribute
+import asyncio
 import json
 
-x = {"servicedata":"712098004a63b6658d7cc40d071003f32600"}
-z = dble(json.dumps(x))
-print(z, "\n")
+from TheengsDecoder import decodeBLE as dble
 
-p = json.loads(z)
-print(getProperties(p['model_id']), "\n")
-brand = getAttribute(p['model_id'], 'brand')
-model = getAttribute(p['model_id'], 'model')
-print("brand:", brand, ", model:", model)
+from unittest import TestCase
 
-y = {}
-z = dble(json.dumps(y))
-print("decoder result (None expected): ", z)
-print("Done")
+
+class TestScanAndDecode(TestCase):
+    def test_th05f(self):
+        data = {"servicedatauuid": "fcd2", "servicedata": "4000720154022e0a03071d0c190b", "name": "TH05F-C451CC", "id": "38:1F:8D:C4:51:CC", "rssi": -79}
+        parsed = json.loads(dble(json.dumps(data)))
+        self.assertEqual(parsed.get("model_id"), "TH05F")
+        self.assertEqual(data.get("servicedata"), parsed.get("servicedata"))
+        self.assertEqual(parsed.get('tempc'), 26.06)
+        self.assertEqual(parsed.get('tempf'), 78.908)
+        self.assertEqual(parsed.get('hum'),   74.31)
+        self.assertEqual(parsed.get('batt'),  84)
+        self.assertEqual(parsed.get('volt'),  2.841)


### PR DESCRIPTION
## Description:
Adds support for the Tuya TH05F  (internal TH05Y - https://pvvx.github.io/TH05F/) device running pvvx v2.1 firmware


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
