### PR TITLE
nodejs/theengs-decoder: fix for newer nodejs versions

### DIFF
--- a/nodejs/theengs-decoder/package.json
+++ b/nodejs/theengs-decoder/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "node --test test/"
+    "test": "node --test test/*.test.js"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Description:

nodejs glob behaviour changed. This should be backwards compatible.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
