### PR TITLE
publish_docs: check out submodules so WASM build can find ArduinoJson.h

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -9,6 +9,8 @@ jobs:
     name: Create the documentation and deploy it to GitHub Pages
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary
- The `Build browser WebAssembly decoder` step added to `publish_docs.yml` in #697 fails because `actions/checkout@v4` does not initialize submodules by default, and `ArduinoJson.h` lives in the `src/arduino_json` submodule.
- This caused the v2.3.0 docs publish to fail with `fatal error: 'ArduinoJson.h' file not found` ([run](https://github.com/theengs/decoder/actions/runs/27046622102/job/79833756842)).
- The other C++ build jobs (`gcc`, `clang`, `xcode` in `PR_build.yml`, and `publish_npm.yml`) already pass `submodules: recursive`; this one was missed.

## Test plan
- [ ] After merge, trigger `Create and publish documentation` via `workflow_dispatch` against `development` and confirm the WASM build step succeeds and the `/parser` page deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)