### PR TITLE
publish_npm: use Trusted Publishing (OIDC) for auth, not NPM_TOKEN

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -28,6 +28,9 @@ jobs:
         node-version: '20'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Upgrade npm for Trusted Publishing
+      run: npm install -g npm@latest
+
     - name: Set up Emscripten
       uses: mymindstorm/setup-emsdk@v14
       with:
@@ -70,12 +73,8 @@ jobs:
 
     - name: Publish theengs-decoder to npm
       working-directory: nodejs/theengs-decoder
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: npm publish --provenance --access public
 
     - name: Publish node-red-contrib-theengs-decoder to npm
       working-directory: nodejs/node-red-contrib-theengs-decoder
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Trusted Publishing is now configured on npmjs.org for `theengs-decoder` (repo `theengs/decoder`, workflow `publish_npm.yml`).
- The v2.3.0 publish ([run](https://github.com/theengs/decoder/actions/runs/27046622100/job/79833756850)) still returned `404 Not Found - PUT https://registry.npmjs.org/theengs-decoder` even though the provenance statement was signed successfully. Two causes:
  - Node 20 ships with npm 10.x. On npm < 11.5.1, OIDC is used only for provenance attestation; authentication still falls back to `NODE_AUTH_TOKEN`. With `NPM_TOKEN` no longer valid (since Trusted Publishing replaced it), the PUT was unauthorized → 404.
  - Full OIDC auth for `npm publish` requires npm 11.5.1+.
- Upgrade npm to latest before publish, and remove the `NODE_AUTH_TOKEN` env from the two publish steps so the CLI uses the Trusted Publisher flow end-to-end.
- Once this merges, the `NPM_TOKEN` secret can be deleted from the repo.

## Test plan
- [ ] After merge, trigger `Publish to npm` via `workflow_dispatch` with the version input set to `2.3.0` (or re-publish the v2.3.0 release) and confirm both `theengs-decoder@2.3.0` and `node-red-contrib-theengs-decoder@2.3.0` appear on npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)