### PR TITLE
Add Schneider Electric Odace SFSP decoder

### DIFF
--- a/docs/devices/ODACE-WLBL.md
+++ b/docs/devices/ODACE-WLBL.md
@@ -1,0 +1,26 @@
+# Schneider Electric Odace SFSP / Odace WLBL one way switch
+
+|Model Id|[S520104](https://github.com/theengs/decoder/blob/development/src/devices/ODACE_WLBL_json.h)|
+|-|-|
+|Brand|Schneider Electric|
+|Model|Odace WLBL (Odace SFSP in French-speaking markets)|
+|Short Description|Bluetooth event switch|
+|Communication|BLE broadcast|
+|Frequency|2.4Ghz|
+|Power Source|Kinetic energy harvesting (battery-free)|
+|Exchanged Data|device UID, button action|
+|Encrypted|No|
+
+The button action is encoded as:
+
+* 0 - Off
+* 1 - On
+* 2 - Toggle
+* 3 - Dim up
+* 4 - Dim down
+* 5 - Up
+* 6 - Down
+* 7 - Stop
+* 8 - User scene
+* 9 - Scene in
+* 10 - Scene out

--- a/docs/participate/adding-decoders.md
+++ b/docs/participate/adding-decoders.md
@@ -247,6 +247,7 @@ The first parameter is the name of the function to call, The available functions
 - "value_from_hex_data"  - converts the hex string value into an `integer` or `double` type.
 - "bf_value_from_hex_data" - converts the (binary fraction) hex string value into a `double` type.  This should be used when the hex data is represented in the format of `XX.XX`. For example: when `0x1a1e` should output 26.30.
 - "string_from_hex_data" - converts the hex value to a string type.
+- "reverse_string_from_hex_data" - reverses the hex value byte-wise and converts it to a string type.
 - "ascii_from_hex_data" - converts the hex value to ASCII text.
 - "static_value" - sets the value to the static value specified if the condition is met.
 - "bit_static_value" - sets the value to either one of two given values, depending on the evaluated binary bit.

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -900,6 +900,12 @@ int TheengsDecoder::decodeBLEJson(JsonObject& jsondata) {
 
             std::string value(src + decoder[2].as<int>(), decoder[3].as<int>());
 
+            if (strstr((const char*)decoder[0], "reverse_") != nullptr) {
+              std::string reversed(value.length(), '\0');
+              reverse_hex_data(value.c_str(), &reversed[0], value.length());
+              value = reversed;
+            }
+
             /* Lookup table */
             if (prop.containsKey("lookup")) {
               JsonArray lookup = prop["lookup"];

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -185,6 +185,7 @@ public:
     SE_TEMP,
     SE_TPROBE,
     SE_MAG,
+    ODACE_WLBL,
     SBBT_002C,
     SBBT_002C_ENCR,
     SBBT_004CEU_US,

--- a/src/devices.h
+++ b/src/devices.h
@@ -131,6 +131,7 @@
 #include "devices/SE_TEMP_json.h"
 #include "devices/SE_TPROBE_json.h"
 #include "devices/SE_MAG_json.h"
+#include "devices/ODACE_WLBL_json.h"
 #include "devices/SBBT_002C_json.h"
 #include "devices/SBBT_002C_ENCR_json.h"
 #include "devices/SBBT_004CEU_US_json.h"
@@ -283,6 +284,7 @@ const char* _devices[][2] = {
     {_SE_TEMP_json, _SE_TEMP_json_props},
     {_SE_TPROBE_json, _SE_TPROBE_json_props},
     {_SE_MAG_json, _SE_MAG_json_props},
+    {_ODACE_WLBL_json, _ODACE_WLBL_json_props},
     {_SBBT_002C_json, _SBBT_002C_json_props},
     {_SBBT_002C_ENCR_json, _SBBT_002C_ENCR_json_props},
     {_SBBT_004CEU_US_json, _SBBT_004CEU_US_json_props},

--- a/src/devices/ODACE_WLBL_json.h
+++ b/src/devices/ODACE_WLBL_json.h
@@ -1,0 +1,46 @@
+const char* _ODACE_WLBL_json = "{\"brand\":\"Schneider Electric\",\"model\":\"Odace WLBL\",\"model_id\":\"S520104\",\"tag\":\"1104\",\"condition\":[\"manufacturerdata\",\">=\",24,\"index\",0,\"b6028e44\"],\"properties\":{\"uid\":{\"decoder\":[\"reverse_string_from_hex_data\",\"manufacturerdata\",14,6]},\"action\":{\"decoder\":[\"string_from_hex_data\",\"manufacturerdata\",22,2],\"lookup\":[\"00\",\"off\",\"01\",\"on\",\"02\",\"toggle\",\"03\",\"dim_up\",\"04\",\"dim_down\",\"05\",\"up\",\"06\",\"down\",\"07\",\"stop\",\"08\",\"scene_user\",\"09\",\"scene_in\",\"0a\",\"scene_out\"]}}}";
+
+/*R""""(
+{
+   "brand":"Schneider Electric",
+   "model":"Odace WLBL",
+   "model_id":"S520104",
+   "tag":"1104",
+   "condition":["manufacturerdata", ">=", 24, "index", 0, "b6028e44"],
+   "properties":{
+      "uid":{
+         "decoder":["reverse_string_from_hex_data", "manufacturerdata", 14, 6]
+      },
+      "action":{
+         "decoder":["string_from_hex_data", "manufacturerdata", 22, 2],
+         "lookup":["00", "off",
+                   "01", "on",
+                   "02", "toggle",
+                   "03", "dim_up",
+                   "04", "dim_down",
+                   "05", "up",
+                   "06", "down",
+                   "07", "stop",
+                   "08", "scene_user",
+                   "09", "scene_in",
+                   "0a", "scene_out"]
+      }
+   }
+})"""";*/
+
+const char* _ODACE_WLBL_json_props = "{\"properties\":{\"uid\":{\"unit\":\"string\",\"name\":\"device UID\"},\"action\":{\"unit\":\"event\",\"name\":\"button action\",\"events\":[\"off\",\"on\",\"toggle\",\"dim_up\",\"dim_down\",\"up\",\"down\",\"stop\",\"scene_user\",\"scene_in\",\"scene_out\"]}}}";
+
+/*R""""(
+{
+   "properties":{
+      "uid":{
+         "unit":"string",
+         "name":"device UID"
+      },
+      "action":{
+         "unit":"event",
+         "name":"button action",
+         "events":["off", "on", "toggle", "dim_up", "dim_down", "up", "down", "stop", "scene_user", "scene_in", "scene_out"]
+      }
+   }
+})"""";*/

--- a/tests/BLE/test_ble.cpp
+++ b/tests/BLE/test_ble.cpp
@@ -244,6 +244,9 @@ const char* expected_mfg[] = {
     "{\"brand\":\"Victron Energy\",\"model\":\"Victron encrypted\",\"model_id\":\"VICTRON_ENCR\",\"type\":\"ENRG\",\"encr\":3,\"cipher\":\"9b17c12f82e66b50ccc629e5\",\"ctr\":\"66a7\",\"mic\":\"13\"}",
     "{\"brand\":\"Victron Energy\",\"model\":\"Solar Charge Controller\",\"model_id\":\"VICTSCC\",\"type\":\"ENRG\",\"track\":true,\"bvpp\":true,\"device_state\":\"off\",\"volt_batt\":13.28,\"current_batt\":0,\"yield_today\":0.01,\"pv_power\":0,\"current_load\":0,\"error_code\":0}",
     "{\"brand\":\"Victron Energy\",\"model\":\"Solar Charge Controller\",\"model_id\":\"VICTSCC\",\"type\":\"ENRG\",\"track\":true,\"bvpp\":true,\"device_state\":\"absorption\",\"volt_batt\":14.18,\"current_batt\":0,\"yield_today\":0.01,\"pv_power\":1,\"current_load\":0.1,\"error_code\":0}",
+    "{\"brand\":\"Schneider Electric\",\"model\":\"Odace WLBL\",\"model_id\":\"S520104\",\"type\":\"BTN\",\"cont\":true,\"uid\":\"005942\",\"action\":\"toggle\"}",
+    "{\"brand\":\"Schneider Electric\",\"model\":\"Odace WLBL\",\"model_id\":\"S520104\",\"type\":\"BTN\",\"cont\":true,\"uid\":\"005942\",\"action\":\"toggle\"}",
+    "{\"brand\":\"Schneider Electric\",\"model\":\"Odace WLBL\",\"model_id\":\"S520104\",\"type\":\"BTN\",\"cont\":true,\"uid\":\"005942\",\"action\":\"toggle\"}",
 };
 
 const char* expected_name_uuid_mfgsvcdata[] = {
@@ -843,6 +846,9 @@ const char* test_mfgdata[][3] = {
     {"Victron MPPT 75/15 ENCR", "", "e102108275a00166a7139b17c12f82e66b50ccc629e5"},
     {"Victron MPPT 75/15", "", "e102118275a001ffff130000300500000100000000fe"},
     {"Victron MPPT 75/15", "", "e102118275a001ffff1304008a0500000100010001fe"},
+    {"Odace WLBL", "", "b6028e4401010042590001020000040000000000923995c4cc19"},
+    {"Odace WLBL", "", "b6028e4401010042590001020000040000000000232c37285846"},
+    {"Odace WLBL", "", "b6028e44010100425900010200000400000000005b2bd3805d97"},
 };
 
 TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
@@ -1070,6 +1076,9 @@ TheengsDecoder::BLE_ID_NUM test_mfgdata_id_num[]{
     TheengsDecoder::BLE_ID_NUM::VICTRON_ENCR,
     TheengsDecoder::BLE_ID_NUM::VICTSCC,
     TheengsDecoder::BLE_ID_NUM::VICTSCC,
+    TheengsDecoder::BLE_ID_NUM::ODACE_WLBL,
+    TheengsDecoder::BLE_ID_NUM::ODACE_WLBL,
+    TheengsDecoder::BLE_ID_NUM::ODACE_WLBL,
 };
 
 // uuid test input [test name] [device name] [uuid] [manufacturer data] [service data]


### PR DESCRIPTION
## Description

Add native decoding support for the Schneider Electric Odace SFSP S520104 BLE event switch.

- Detect manufacturer data with the `b6028e44` signature.
- Decode the three-byte little-endian UID while preserving leading zeroes.
- Map action codes `0x00` through `0x0a` to readable button events.
- Declare the device as type `BTN` with event metadata for downstream consumers.
- Add the captured advertisement as a regression test, including repeated decoding.
- Document the BLE format, MQTT output, and a Home Assistant example.

Captured advertisement:

`b6028e4401010042590001020000040000000000923995c4cc19`

Decoded result includes UID `005942` and action `toggle`.

Hardware validation was performed with a Schneider Electric Odace SFSP S520104, a Sena UD100 Bluetooth adapter, Debian 11, Theengs Gateway, MQTT, and Home Assistant.

## Checklist

- [x] The pull request is done against the latest development branch
- [x] Only one feature/fix was added per PR and the code change compiles without warnings
- [x] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
